### PR TITLE
Disable dependency metadata

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,12 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 


### PR DESCRIPTION
This is a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367), [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056) and [here](https://android.izzysoft.de/articles/named/iod-scan-apkchecks?lang=en#blobs).
