### PR TITLE
Bug fix request

### DIFF
--- a/app/src/main/java/com/hfut/schedule/ui/activity/home/cube/items/subitems/FocusCardSettings.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/activity/home/cube/items/subitems/FocusCardSettings.kt
@@ -351,7 +351,7 @@ fun getWebNew(vm: NetWorkViewModel, vmUI : UIViewModel)  {
         Handler(Looper.getMainLooper()).post{
             vm.infoValue.observeForever { result ->
                 if (result != null)
-                    if(result.contains("success")) {
+                    if(result.contains("success")&&!result.contains("账号不存在")) {
                         val data = Gson().fromJson(result,FeeResponse::class.java).map.showData
 
                        vmUI.webValue.value = data["本期已使用流量"]?.let {


### PR DESCRIPTION
来自合肥校区
相关模块:getWebNew
已知问题:
合肥校区可以得到含有suceess的响应,但是不包含有效信息,会包含"账号不存在"
由于每次打开app这个模块会自动调起,并且在本人(合肥校区学生)设备上会crash
解决方法:
在getWebNew函数中添加判断,如果响应中包含"账号不存在"则视作请求失败
未来可能会帮助增加实现合肥校区相关代码