### PR TITLE
尝试fix-课程过多导致超出定时闹钟提醒500limit限制从而闪退

### DIFF
--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
@@ -19,6 +19,9 @@ import com.hfut.schedule.application.MyApplication
 import com.hfut.schedule.R
 import com.hfut.schedule.logic.util.other.AppVersion
 import com.hfut.schedule.logic.util.sys.datetime.DateTimeManager.getPassedMinutesInRange
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 import kotlin.math.ceil
 
 object AppNotificationManager {
@@ -156,13 +159,13 @@ object AppNotificationManager {
         val teacherText = teacher?.takeIf { it.isNotBlank() }
         val contentText = if (eventType == "考试") {
             listOfNotNull(
-                teacherText?.let { "类型:$it" },
-                "地点:$placeText",
+                teacherText?.let { "$it" },
+                "$placeText",
             ).joinToString(" | ")
         } else {
-            "老师:${teacherText ?: "待确认"} | 地点:$placeText"
+            "${teacherText ?: "老师待确认"} | $placeText"
         }
-        val subText = buildCourseLiveSubText(startMillis, endMillis, eventType)
+        val subText = buildCourseLiveSubText(startMillis, endMillis)
         val shortPlaceText = buildShortPlaceText(placeText)
 
         val notification = if (AppVersion.sdkInt >= 36) {
@@ -174,7 +177,7 @@ object AppNotificationManager {
                 shortText = shortPlaceText,
                 startMillis = startMillis,
                 endMillis = endMillis,
-                contentIntent = contentIntent
+                contentIntent = contentIntent,
             )
         } else {
             NotificationCompat.Builder(context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
@@ -231,15 +234,9 @@ object AppNotificationManager {
             .build()
     }
 
-    private fun buildCourseLiveSubText(startMillis: Long, endMillis: Long, eventType: String): String {
-        val now = System.currentTimeMillis()
-        return if (now < startMillis) {
-            val minutes = ceil((startMillis - now) / 60_000.0).toInt().coerceAtLeast(1)
-            "${minutes}分钟后${eventType}"
-        } else {
-            val minutes = ceil((endMillis - now) / 60_000.0).toInt().coerceAtLeast(1)
-            "${minutes}分钟后结束"
-        }
+    private fun buildCourseLiveSubText(startMillis: Long, endMillis: Long): String {
+        val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
+        return "${formatter.format(Date(startMillis))}-${formatter.format(Date(endMillis))}"
     }
 
     private fun buildShortPlaceText(placeText: String): String {

--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
@@ -167,6 +167,7 @@ object AppNotificationManager {
         }
         val subText = buildCourseLiveSubText(startMillis, endMillis)
         val shortPlaceText = buildShortPlaceText(placeText)
+        val smallIconRes = buildCourseLiveSmallIconRes(eventType)
 
         val notification = if (AppVersion.sdkInt >= 36) {
             buildAndroid16CourseLiveNotification(
@@ -178,10 +179,11 @@ object AppNotificationManager {
                 startMillis = startMillis,
                 endMillis = endMillis,
                 contentIntent = contentIntent,
+                smallIconRes = smallIconRes,
             )
         } else {
             NotificationCompat.Builder(context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
-                .setSmallIcon(R.drawable.hfut_badge_white)
+                .setSmallIcon(smallIconRes)
                 .setContentTitle("${eventType}提醒：$courseName")
                 .setContentText(contentText)
                 .setStyle(NotificationCompat.BigTextStyle().bigText("$contentText\n点击查看详情"))
@@ -211,9 +213,10 @@ object AppNotificationManager {
         startMillis: Long,
         endMillis: Long,
         contentIntent: PendingIntent,
+        smallIconRes: Int,
     ): Notification {
         return Notification.Builder(MyApplication.context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
-            .setSmallIcon(R.drawable.hfut_badge_white)
+            .setSmallIcon(smallIconRes)
             .setLargeIcon(Icon.createWithResource(MyApplication.context, R.drawable.hfut_badge))
             .setContentTitle("${eventType}提醒：$courseName")
             .setContentText(contentText)
@@ -238,6 +241,9 @@ object AppNotificationManager {
         val formatter = SimpleDateFormat("HH:mm", Locale.getDefault())
         return "${formatter.format(Date(startMillis))}-${formatter.format(Date(endMillis))}"
     }
+
+    private fun buildCourseLiveSmallIconRes(eventType: String): Int =
+        if (eventType == "考试") R.drawable.quiz_24 else R.drawable.book_24
 
     private fun buildShortPlaceText(placeText: String): String {
         val compactText = placeText

--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
@@ -19,9 +19,7 @@ import com.hfut.schedule.application.MyApplication
 import com.hfut.schedule.R
 import com.hfut.schedule.logic.util.other.AppVersion
 import com.hfut.schedule.logic.util.sys.datetime.DateTimeManager.getPassedMinutesInRange
-import java.time.Duration
 import kotlin.math.ceil
-import kotlin.math.roundToInt
 
 object AppNotificationManager {
 
@@ -180,7 +178,8 @@ object AppNotificationManager {
                 .setOngoing(true)
                 .setAutoCancel(false)
                 .setOnlyAlertOnce(true)
-                .setShowWhen(false)
+                .setWhen(startMillis)
+                .setShowWhen(true)
                 .build()
         }
 
@@ -200,39 +199,25 @@ object AppNotificationManager {
         endMillis: Long,
         contentIntent: PendingIntent,
     ): Notification {
-        val now = System.currentTimeMillis()
-        val totalMinutes = Duration.ofMillis((endMillis - startMillis).coerceAtLeast(1)).toMinutes().toInt().coerceAtLeast(1)
-        val passedMinutes = Duration.ofMillis((now - startMillis).coerceAtLeast(0)).toMinutes().toInt()
-        val progress = ((passedMinutes.toFloat() / totalMinutes) * 1000).roundToInt().coerceIn(0, 1000)
-        val passedSegment = progress.coerceIn(1, 999)
-
-        val style = Notification.ProgressStyle()
-            .setStyledByProgress(false)
-            .setProgress(progress)
-            .setProgressSegments(
-                listOf(
-                    Notification.ProgressStyle.Segment(passedSegment).setColor(Color.GREEN),
-                    Notification.ProgressStyle.Segment(1000 - passedSegment).setColor(Color.LTGRAY),
-                )
-            )
-
         return Notification.Builder(MyApplication.context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
             .setSmallIcon(R.drawable.hfut_badge_white)
             .setLargeIcon(Icon.createWithResource(MyApplication.context, R.drawable.hfut_badge))
             .setContentTitle("上课提醒：$courseName")
             .setContentText(contentText)
+            .setStyle(Notification.BigTextStyle().bigText("$contentText\n$subText"))
             .setSubText(subText)
             .setShortCriticalText(shortText)
             .setContentIntent(contentIntent)
-            .setShowWhen(false)
+            .setWhen(startMillis)
+            .setShowWhen(true)
             .setOngoing(true)
+            .setAutoCancel(false)
             .setOnlyAlertOnce(true)
             .setPriority(Notification.PRIORITY_HIGH)
             .setCategory(Notification.CATEGORY_EVENT)
             .addExtras(Bundle().apply {
                 putBoolean(EXTRA_REQUEST_PROMOTED_ONGOING, true)
             })
-            .setStyle(style)
             .build()
     }
 

--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/AppNotificationManager.kt
@@ -144,6 +144,7 @@ object AppNotificationManager {
         startMillis: Long,
         endMillis: Long,
         contentIntent: PendingIntent,
+        eventType: String = "上课",
         asForeground: Boolean = false,
     ): Notification? {
         if (!canPostNotification()) return null
@@ -152,13 +153,21 @@ object AppNotificationManager {
         val context = MyApplication.context
         val notificationId = courseLiveNotificationId(courseName, startMillis)
         val placeText = place?.takeIf { it.isNotBlank() } ?: "教室待确认"
-        val teacherText = teacher?.takeIf { it.isNotBlank() } ?: "待确认"
-        val contentText = "老师:$teacherText | 地点:$placeText"
-        val subText = buildCourseLiveSubText(startMillis, endMillis)
+        val teacherText = teacher?.takeIf { it.isNotBlank() }
+        val contentText = if (eventType == "考试") {
+            listOfNotNull(
+                teacherText?.let { "类型:$it" },
+                "地点:$placeText",
+            ).joinToString(" | ")
+        } else {
+            "老师:${teacherText ?: "待确认"} | 地点:$placeText"
+        }
+        val subText = buildCourseLiveSubText(startMillis, endMillis, eventType)
         val shortPlaceText = buildShortPlaceText(placeText)
 
         val notification = if (AppVersion.sdkInt >= 36) {
             buildAndroid16CourseLiveNotification(
+                eventType = eventType,
                 courseName = courseName,
                 contentText = contentText,
                 subText = subText,
@@ -170,9 +179,9 @@ object AppNotificationManager {
         } else {
             NotificationCompat.Builder(context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
                 .setSmallIcon(R.drawable.hfut_badge_white)
-                .setContentTitle("上课提醒：$courseName")
+                .setContentTitle("${eventType}提醒：$courseName")
                 .setContentText(contentText)
-                .setStyle(NotificationCompat.BigTextStyle().bigText("$contentText\n点击查看课程详细信息"))
+                .setStyle(NotificationCompat.BigTextStyle().bigText("$contentText\n点击查看详情"))
                 .setContentIntent(contentIntent)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setOngoing(true)
@@ -191,6 +200,7 @@ object AppNotificationManager {
 
     @RequiresApi(36)
     private fun buildAndroid16CourseLiveNotification(
+        eventType: String,
         courseName: String,
         contentText: String,
         subText: String,
@@ -202,7 +212,7 @@ object AppNotificationManager {
         return Notification.Builder(MyApplication.context, AppNotificationChannel.COURSE_LIVE_UPDATE.name)
             .setSmallIcon(R.drawable.hfut_badge_white)
             .setLargeIcon(Icon.createWithResource(MyApplication.context, R.drawable.hfut_badge))
-            .setContentTitle("上课提醒：$courseName")
+            .setContentTitle("${eventType}提醒：$courseName")
             .setContentText(contentText)
             .setStyle(Notification.BigTextStyle().bigText("$contentText\n$subText"))
             .setSubText(subText)
@@ -221,14 +231,14 @@ object AppNotificationManager {
             .build()
     }
 
-    private fun buildCourseLiveSubText(startMillis: Long, endMillis: Long): String {
+    private fun buildCourseLiveSubText(startMillis: Long, endMillis: Long, eventType: String): String {
         val now = System.currentTimeMillis()
         return if (now < startMillis) {
             val minutes = ceil((startMillis - now) / 60_000.0).toInt().coerceAtLeast(1)
-            "${minutes}分钟后上课"
+            "${minutes}分钟后${eventType}"
         } else {
             val minutes = ceil((endMillis - now) / 60_000.0).toInt().coerceAtLeast(1)
-            "${minutes}分钟后下课"
+            "${minutes}分钟后结束"
         }
     }
 

--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/CourseLiveUpdateScheduler.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/CourseLiveUpdateScheduler.kt
@@ -14,6 +14,7 @@ import com.hfut.schedule.logic.util.storage.kv.DataStoreManager
 import com.hfut.schedule.receiver.CourseLiveUpdateReceiver
 import com.hfut.schedule.service.CourseLiveUpdateService
 import com.hfut.schedule.ui.nav.destination.CourseLiveUpdateDetailDestination
+import com.hfut.schedule.ui.screen.home.calendar.common.examToCalendar
 import com.xah.shared.LogUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -30,6 +31,7 @@ object CourseLiveUpdateScheduler {
     const val EXTRA_TEACHER = "teacher"
     const val EXTRA_START_MILLIS = "start_millis"
     const val EXTRA_END_MILLIS = "end_millis"
+    const val EXTRA_EVENT_TYPE = "event_type"
 
     private const val DEFAULT_REMIND_BEFORE_MINUTES = 20
     private const val WINDOW_CHECK_INTERVAL_MILLIS = 10 * 60_000L
@@ -42,55 +44,55 @@ object CourseLiveUpdateScheduler {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val now = System.currentTimeMillis()
         val remindBeforeMinutes = getRemindBeforeMinutes()
-        val courses = getJxglstuCourseSchedule()
-            .filter { it.time.end.toMillis() > now }
-            .sortedBy { it.time.start.toMillis() }
+        val reminderItems = getLiveReminderItems()
+            .filter { it.endMillis > now }
+            .sortedBy { it.startMillis }
         val alarmRequests = mutableListOf<CourseAlarmRequest>()
         val scheduledCourseKeys = mutableSetOf<String>()
 
         cancelScheduledAlarms(
             context = context,
             alarmManager = alarmManager,
-            courses = courses,
+            reminderItems = reminderItems,
             remindBeforeMinutes = remindBeforeMinutes,
             cancelNotifications = false,
         )
 
-        courses.forEach { course ->
-            val startMillis = course.time.start.toMillis()
-            val endMillis = course.time.end.toMillis()
+        reminderItems.forEach { item ->
+            val startMillis = item.startMillis
+            val endMillis = item.endMillis
             val triggerMillis = startMillis - remindBeforeMinutes * 60_000L
-            val courseKey = "${course.courseName}@$startMillis"
+            val courseKey = "${item.title}@$startMillis"
 
             if (triggerMillis > now) {
                 val showIntent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
                     action = ACTION_SHOW
-                    putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
+                    putCourseExtras(item.title, item.place, item.subtitle, startMillis, endMillis, item.eventType)
                 }
                 alarmRequests += CourseAlarmRequest(
                     triggerMillis = triggerMillis,
                     pendingIntent = PendingIntent.getBroadcast(
                         context,
-                        requestCode(course.courseName, startMillis, ACTION_SHOW),
+                        requestCode(item.title, startMillis, ACTION_SHOW),
                         showIntent,
                         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                     ),
                     alarmClockInfo = AlarmManager.AlarmClockInfo(
                         triggerMillis,
-                        buildOpenCourseIntent(context, course.courseName, course.place, startMillis)
+                        buildOpenIntent(context, item)
                     )
                 )
             }
 
             val finishIntent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
                 action = ACTION_FINISH
-                putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
+                putCourseExtras(item.title, item.place, item.subtitle, startMillis, endMillis, item.eventType)
             }
             alarmRequests += CourseAlarmRequest(
                 triggerMillis = endMillis,
                 pendingIntent = PendingIntent.getBroadcast(
                     context,
-                    requestCode(course.courseName, startMillis, ACTION_FINISH),
+                    requestCode(item.title, startMillis, ACTION_FINISH),
                     finishIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
@@ -132,19 +134,20 @@ object CourseLiveUpdateScheduler {
         val now = System.currentTimeMillis()
         val remindBeforeMinutes = getRemindBeforeMinutes()
         var shownCount = 0
-        getJxglstuCourseSchedule().forEach { course ->
-            val startMillis = course.time.start.toMillis()
-            val endMillis = course.time.end.toMillis()
+        getLiveReminderItems().forEach { item ->
+            val startMillis = item.startMillis
+            val endMillis = item.endMillis
             val remindStartMillis = startMillis - remindBeforeMinutes * 60_000L
             if (now !in remindStartMillis until endMillis) return@forEach
 
             AppNotificationManager.showCourseLiveUpdate(
-                courseName = course.courseName,
-                place = course.place,
-                teacher = course.teacher,
+                courseName = item.title,
+                place = item.place,
+                teacher = item.subtitle,
                 startMillis = startMillis,
                 endMillis = endMillis,
-                contentIntent = buildOpenCourseIntent(context, course.courseName, course.place, startMillis),
+                contentIntent = buildOpenIntent(context, item),
+                eventType = item.eventType,
             )
             shownCount++
         }
@@ -157,7 +160,7 @@ object CourseLiveUpdateScheduler {
         cancelScheduledAlarms(
             context = context,
             alarmManager = alarmManager,
-            courses = getJxglstuCourseSchedule(),
+            reminderItems = getLiveReminderItems(),
             remindBeforeMinutes = remindBeforeMinutes,
             cancelNotifications = true,
         )
@@ -167,23 +170,23 @@ object CourseLiveUpdateScheduler {
     private fun cancelScheduledAlarms(
         context: Context,
         alarmManager: AlarmManager,
-        courses: List<JxglstuCourseSchedule>,
+        reminderItems: List<LiveReminderItem>,
         remindBeforeMinutes: Int,
         cancelNotifications: Boolean,
     ) {
         cancelRescheduleAlarm(context, alarmManager)
-        courses.forEach { course ->
-            val startMillis = course.time.start.toMillis()
-            val endMillis = course.time.end.toMillis()
+        reminderItems.forEach { item ->
+            val startMillis = item.startMillis
+            val endMillis = item.endMillis
             val remindStartMillis = startMillis - remindBeforeMinutes * 60_000L
             listOf(ACTION_SHOW, ACTION_FINISH).forEach { action ->
                 val intent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
                     this.action = action
-                    putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
+                    putCourseExtras(item.title, item.place, item.subtitle, startMillis, endMillis, item.eventType)
                 }
                 val pendingIntent = PendingIntent.getBroadcast(
                     context,
-                    requestCode(course.courseName, startMillis, action),
+                    requestCode(item.title, startMillis, action),
                     intent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
@@ -192,15 +195,15 @@ object CourseLiveUpdateScheduler {
             cancelWindowChecks(
                 context = context,
                 alarmManager = alarmManager,
-                courseName = course.courseName,
-                place = course.place,
-                teacher = course.teacher,
+                courseName = item.title,
+                place = item.place,
+                teacher = item.subtitle,
                 remindStartMillis = remindStartMillis,
                 startMillis = startMillis,
                 endMillis = endMillis
             )
             if (cancelNotifications) {
-                AppNotificationManager.cancelCourseLiveUpdate(course.courseName, startMillis)
+                AppNotificationManager.cancelCourseLiveUpdate(item.title, startMillis)
             }
         }
     }
@@ -230,6 +233,41 @@ object CourseLiveUpdateScheduler {
             },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+
+    private suspend fun getLiveReminderItems(): List<LiveReminderItem> =
+        getCourseReminderItems() + getExamReminderItems()
+
+    private suspend fun getCourseReminderItems(): List<LiveReminderItem> =
+        getJxglstuCourseSchedule().map { course ->
+            LiveReminderItem(
+                title = course.courseName,
+                place = course.place,
+                subtitle = course.teacher,
+                startMillis = course.time.start.toMillis(),
+                endMillis = course.time.end.toMillis(),
+                eventType = "上课",
+                destination = LiveReminderDestination.COURSE,
+            )
+        }
+
+    private suspend fun getExamReminderItems(): List<LiveReminderItem> =
+        examToCalendar().mapNotNull { exam ->
+            val day = exam.day ?: return@mapNotNull null
+            val startTime = exam.startTime ?: return@mapNotNull null
+            val endTime = exam.endTime ?: return@mapNotNull null
+            val title = exam.course ?: return@mapNotNull null
+            val startMillis = parseReminderMillis(day, startTime) ?: return@mapNotNull null
+            val endMillis = parseReminderMillis(day, endTime) ?: return@mapNotNull null
+            LiveReminderItem(
+                title = title,
+                place = exam.place,
+                subtitle = exam.type,
+                startMillis = startMillis,
+                endMillis = endMillis,
+                eventType = "考试",
+                destination = LiveReminderDestination.EXAM,
+            )
+        }
 
     private fun cancelWindowChecks(
         context: Context,
@@ -274,6 +312,45 @@ object CourseLiveUpdateScheduler {
         return PendingIntent.getActivity(
             context,
             requestCode(courseName, startMillis, "open"),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    fun buildOpenLiveReminderIntent(
+        context: Context,
+        eventType: String,
+        title: String,
+        place: String?,
+        startMillis: Long,
+    ): PendingIntent =
+        if (eventType == "考试") {
+            buildOpenExamIntent(context, title, place, startMillis)
+        } else {
+            buildOpenCourseIntent(context, title, place, startMillis)
+        }
+
+    private fun buildOpenIntent(context: Context, item: LiveReminderItem): PendingIntent =
+        when (item.destination) {
+            LiveReminderDestination.COURSE -> buildOpenCourseIntent(context, item.title, item.place, item.startMillis)
+            LiveReminderDestination.EXAM -> buildOpenExamIntent(context, item.title, item.place, item.startMillis)
+        }
+
+    private fun buildOpenExamIntent(
+        context: Context,
+        examName: String,
+        place: String?,
+        startMillis: Long,
+    ): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra(EXTRA_COURSE_NAME, examName)
+            putExtra(EXTRA_PLACE, place)
+            putExtra(EXTRA_START_MILLIS, startMillis)
+        }
+        return PendingIntent.getActivity(
+            context,
+            requestCode(examName, startMillis, "open_exam"),
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -324,6 +401,21 @@ object CourseLiveUpdateScheduler {
         val alarmClockInfo: AlarmManager.AlarmClockInfo? = null,
     )
 
+    private data class LiveReminderItem(
+        val title: String,
+        val place: String?,
+        val subtitle: String?,
+        val startMillis: Long,
+        val endMillis: Long,
+        val eventType: String,
+        val destination: LiveReminderDestination,
+    )
+
+    private enum class LiveReminderDestination {
+        COURSE,
+        EXAM,
+    }
+
     fun canPostNotification(context: Context): Boolean =
         Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
                 ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
@@ -339,12 +431,14 @@ object CourseLiveUpdateScheduler {
         teacher: String?,
         startMillis: Long,
         endMillis: Long,
+        eventType: String = "上课",
     ) {
         putExtra(EXTRA_COURSE_NAME, courseName)
         putExtra(EXTRA_PLACE, place)
         putExtra(EXTRA_TEACHER, teacher)
         putExtra(EXTRA_START_MILLIS, startMillis)
         putExtra(EXTRA_END_MILLIS, endMillis)
+        putExtra(EXTRA_EVENT_TYPE, eventType)
     }
 
     private fun DateTimeBean.toMillis(): Long =
@@ -357,6 +451,24 @@ object CourseLiveUpdateScheduler {
             set(Calendar.SECOND, 0)
             set(Calendar.MILLISECOND, 0)
         }.timeInMillis
+
+    private fun parseReminderMillis(date: String, time: String): Long? {
+        val dateParts = date.split("-").mapNotNull { it.toIntOrNull() }
+        val timeParts = time.split(":").mapNotNull { it.toIntOrNull() }
+        if (dateParts.size != 3 || timeParts.size != 2) return null
+        return try {
+            DateTimeBean(
+                year = dateParts[0],
+                month = dateParts[1],
+                day = dateParts[2],
+                hour = timeParts[0],
+                minute = timeParts[1],
+            ).toMillis()
+        } catch (e: Exception) {
+            LogUtil.error(e)
+            null
+        }
+    }
 
     private fun requestCode(courseName: String, startMillis: Long, action: String): Int {
         val hash = "$action@$courseName@$startMillis".hashCode()

--- a/app/src/main/java/com/hfut/schedule/logic/util/sys/CourseLiveUpdateScheduler.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/sys/CourseLiveUpdateScheduler.kt
@@ -33,26 +33,41 @@ object CourseLiveUpdateScheduler {
 
     private const val DEFAULT_REMIND_BEFORE_MINUTES = 20
     private const val WINDOW_CHECK_INTERVAL_MILLIS = 10 * 60_000L
+    private const val MAX_SCHEDULED_ALARMS = 420
+    private const val RESCHEDULE_INTERVAL_MILLIS = 6 * 60 * 60_000L
+    private const val RESCHEDULE_BEFORE_NEXT_MILLIS = 30 * 60_000L
+    private const val RESCHEDULE_REQUEST_CODE = 0x436F7572
 
     suspend fun scheduleAll(context: Context = MyApplication.context): Int = withContext(Dispatchers.IO) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val now = System.currentTimeMillis()
         val remindBeforeMinutes = getRemindBeforeMinutes()
-        var scheduledCount = 0
+        val courses = getJxglstuCourseSchedule()
+            .filter { it.time.end.toMillis() > now }
+            .sortedBy { it.time.start.toMillis() }
+        val alarmRequests = mutableListOf<CourseAlarmRequest>()
+        val scheduledCourseKeys = mutableSetOf<String>()
 
-        getJxglstuCourseSchedule().forEach { course ->
+        cancelScheduledAlarms(
+            context = context,
+            alarmManager = alarmManager,
+            courses = courses,
+            remindBeforeMinutes = remindBeforeMinutes,
+            cancelNotifications = false,
+        )
+
+        courses.forEach { course ->
             val startMillis = course.time.start.toMillis()
             val endMillis = course.time.end.toMillis()
             val triggerMillis = startMillis - remindBeforeMinutes * 60_000L
-            if (endMillis <= now) return@forEach
+            val courseKey = "${course.courseName}@$startMillis"
 
             if (triggerMillis > now) {
                 val showIntent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
                     action = ACTION_SHOW
                     putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
                 }
-                setCourseAlarm(
-                    alarmManager = alarmManager,
+                alarmRequests += CourseAlarmRequest(
                     triggerMillis = triggerMillis,
                     pendingIntent = PendingIntent.getBroadcast(
                         context,
@@ -67,24 +82,11 @@ object CourseLiveUpdateScheduler {
                 )
             }
 
-            scheduleWindowChecks(
-                context = context,
-                alarmManager = alarmManager,
-                courseName = course.courseName,
-                place = course.place,
-                teacher = course.teacher,
-                remindStartMillis = triggerMillis,
-                startMillis = startMillis,
-                endMillis = endMillis,
-                now = now
-            )
-
             val finishIntent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
                 action = ACTION_FINISH
                 putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
             }
-            setCourseAlarm(
-                alarmManager = alarmManager,
+            alarmRequests += CourseAlarmRequest(
                 triggerMillis = endMillis,
                 pendingIntent = PendingIntent.getBroadcast(
                     context,
@@ -93,10 +95,35 @@ object CourseLiveUpdateScheduler {
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
             )
-            scheduledCount++
+            scheduledCourseKeys += courseKey
         }
 
-        scheduledCount
+        val sortedRequests = alarmRequests
+            .filter { it.triggerMillis > now }
+            .sortedBy { it.triggerMillis }
+        val requestsToSchedule = sortedRequests.take(MAX_SCHEDULED_ALARMS)
+        var firstUnscheduledMillis = sortedRequests.getOrNull(requestsToSchedule.size)?.triggerMillis
+        for (request in requestsToSchedule) {
+            if (!setCourseAlarm(
+                    alarmManager = alarmManager,
+                    triggerMillis = request.triggerMillis,
+                    pendingIntent = request.pendingIntent,
+                    alarmClockInfo = request.alarmClockInfo,
+                )
+            ) {
+                firstUnscheduledMillis = request.triggerMillis
+                break
+            }
+        }
+
+        if (firstUnscheduledMillis != null) {
+            val fallbackMillis = now + RESCHEDULE_INTERVAL_MILLIS
+            val triggerMillis = maxOf(now + WINDOW_CHECK_INTERVAL_MILLIS, firstUnscheduledMillis - RESCHEDULE_BEFORE_NEXT_MILLIS)
+                .let { minOf(it, fallbackMillis) }
+            scheduleRescheduleAlarm(context, alarmManager, triggerMillis)
+        }
+
+        scheduledCourseKeys.size
     }
 
     suspend fun showCurrentWindowCourses(context: Context = MyApplication.context): Int = withContext(Dispatchers.IO) {
@@ -111,11 +138,14 @@ object CourseLiveUpdateScheduler {
             val remindStartMillis = startMillis - remindBeforeMinutes * 60_000L
             if (now !in remindStartMillis until endMillis) return@forEach
 
-            val serviceIntent = Intent(context, CourseLiveUpdateService::class.java).apply {
-                action = ACTION_SHOW
-                putCourseExtras(course.courseName, course.place, course.teacher, startMillis, endMillis)
-            }
-            ContextCompat.startForegroundService(context, serviceIntent)
+            AppNotificationManager.showCourseLiveUpdate(
+                courseName = course.courseName,
+                place = course.place,
+                teacher = course.teacher,
+                startMillis = startMillis,
+                endMillis = endMillis,
+                contentIntent = buildOpenCourseIntent(context, course.courseName, course.place, startMillis),
+            )
             shownCount++
         }
         shownCount
@@ -124,7 +154,25 @@ object CourseLiveUpdateScheduler {
     suspend fun cancelAll(context: Context = MyApplication.context) = withContext(Dispatchers.IO) {
         val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         val remindBeforeMinutes = getRemindBeforeMinutes()
-        getJxglstuCourseSchedule().forEach { course ->
+        cancelScheduledAlarms(
+            context = context,
+            alarmManager = alarmManager,
+            courses = getJxglstuCourseSchedule(),
+            remindBeforeMinutes = remindBeforeMinutes,
+            cancelNotifications = true,
+        )
+        CourseLiveUpdateService.stopService(context)
+    }
+
+    private fun cancelScheduledAlarms(
+        context: Context,
+        alarmManager: AlarmManager,
+        courses: List<JxglstuCourseSchedule>,
+        remindBeforeMinutes: Int,
+        cancelNotifications: Boolean,
+    ) {
+        cancelRescheduleAlarm(context, alarmManager)
+        courses.forEach { course ->
             val startMillis = course.time.start.toMillis()
             val endMillis = course.time.end.toMillis()
             val remindStartMillis = startMillis - remindBeforeMinutes * 60_000L
@@ -151,43 +199,37 @@ object CourseLiveUpdateScheduler {
                 startMillis = startMillis,
                 endMillis = endMillis
             )
-            AppNotificationManager.cancelCourseLiveUpdate(course.courseName, startMillis)
+            if (cancelNotifications) {
+                AppNotificationManager.cancelCourseLiveUpdate(course.courseName, startMillis)
+            }
         }
-        CourseLiveUpdateService.stopService(context)
     }
 
-    private fun scheduleWindowChecks(
+    private fun scheduleRescheduleAlarm(
         context: Context,
         alarmManager: AlarmManager,
-        courseName: String,
-        place: String?,
-        teacher: String?,
-        remindStartMillis: Long,
-        startMillis: Long,
-        endMillis: Long,
-        now: Long,
+        triggerMillis: Long,
     ) {
-        var checkMillis = maxOf(startMillis, remindStartMillis + WINDOW_CHECK_INTERVAL_MILLIS)
-        while (checkMillis < endMillis) {
-            if (checkMillis > now) {
-                val intent = Intent(context, CourseLiveUpdateReceiver::class.java).apply {
-                    action = ACTION_SHOW
-                    putCourseExtras(courseName, place, teacher, startMillis, endMillis)
-                }
-                setCourseAlarm(
-                    alarmManager = alarmManager,
-                    triggerMillis = checkMillis,
-                    pendingIntent = PendingIntent.getBroadcast(
-                        context,
-                        requestCode(courseName, startMillis, "$ACTION_SHOW@$checkMillis"),
-                        intent,
-                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                    )
-                )
-            }
-            checkMillis += WINDOW_CHECK_INTERVAL_MILLIS
-        }
+        setCourseAlarm(
+            alarmManager = alarmManager,
+            triggerMillis = triggerMillis,
+            pendingIntent = reschedulePendingIntent(context),
+        )
     }
+
+    private fun cancelRescheduleAlarm(context: Context, alarmManager: AlarmManager) {
+        alarmManager.cancel(reschedulePendingIntent(context))
+    }
+
+    private fun reschedulePendingIntent(context: Context): PendingIntent =
+        PendingIntent.getBroadcast(
+            context,
+            RESCHEDULE_REQUEST_CODE,
+            Intent(context, CourseLiveUpdateReceiver::class.java).apply {
+                action = ACTION_RESCHEDULE
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
 
     private fun cancelWindowChecks(
         context: Context,
@@ -242,11 +284,11 @@ object CourseLiveUpdateScheduler {
         triggerMillis: Long,
         pendingIntent: PendingIntent,
         alarmClockInfo: AlarmManager.AlarmClockInfo? = null,
-    ) {
+    ): Boolean {
         try {
             if (alarmClockInfo != null) {
                 alarmManager.setAlarmClock(alarmClockInfo, pendingIntent)
-                return
+                return true
             }
 
             when {
@@ -262,9 +304,25 @@ object CourseLiveUpdateScheduler {
             }
         } catch (e: SecurityException) {
             LogUtil.error(e)
-            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerMillis, pendingIntent)
+            return try {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerMillis, pendingIntent)
+                true
+            } catch (fallbackException: RuntimeException) {
+                LogUtil.error(fallbackException)
+                false
+            }
+        } catch (e: IllegalStateException) {
+            LogUtil.error(e)
+            return false
         }
+        return true
     }
+
+    private data class CourseAlarmRequest(
+        val triggerMillis: Long,
+        val pendingIntent: PendingIntent,
+        val alarmClockInfo: AlarmManager.AlarmClockInfo? = null,
+    )
 
     fun canPostNotification(context: Context): Boolean =
         Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||

--- a/app/src/main/java/com/hfut/schedule/receiver/CourseLiveUpdateReceiver.kt
+++ b/app/src/main/java/com/hfut/schedule/receiver/CourseLiveUpdateReceiver.kt
@@ -45,17 +45,21 @@ class CourseLiveUpdateReceiver : BroadcastReceiver() {
             AppNotificationManager.cancelCourseLiveUpdate(courseName, startMillis)
             return
         }
+        val eventType = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_EVENT_TYPE) ?: "上课"
+        val place = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE)
 
         AppNotificationManager.showCourseLiveUpdate(
             courseName = courseName,
-            place = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE),
+            place = place,
             teacher = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_TEACHER),
             startMillis = startMillis,
             endMillis = endMillis,
-            contentIntent = CourseLiveUpdateScheduler.buildOpenCourseIntent(
+            eventType = eventType,
+            contentIntent = CourseLiveUpdateScheduler.buildOpenLiveReminderIntent(
                 context = context,
-                courseName = courseName,
-                place = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE),
+                eventType = eventType,
+                title = courseName,
+                place = place,
                 startMillis = startMillis,
             ),
         )

--- a/app/src/main/java/com/hfut/schedule/receiver/CourseLiveUpdateReceiver.kt
+++ b/app/src/main/java/com/hfut/schedule/receiver/CourseLiveUpdateReceiver.kt
@@ -3,11 +3,9 @@ package com.hfut.schedule.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import androidx.core.content.ContextCompat
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager
 import com.hfut.schedule.logic.util.sys.AppNotificationManager
 import com.hfut.schedule.logic.util.sys.CourseLiveUpdateScheduler
-import com.hfut.schedule.service.CourseLiveUpdateService
 import com.xah.shared.LogUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,15 +46,19 @@ class CourseLiveUpdateReceiver : BroadcastReceiver() {
             return
         }
 
-        val serviceIntent = Intent(context, CourseLiveUpdateService::class.java).apply {
-            action = CourseLiveUpdateScheduler.ACTION_SHOW
-            putExtra(CourseLiveUpdateScheduler.EXTRA_COURSE_NAME, courseName)
-            putExtra(CourseLiveUpdateScheduler.EXTRA_PLACE, intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE))
-            putExtra(CourseLiveUpdateScheduler.EXTRA_TEACHER, intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_TEACHER))
-            putExtra(CourseLiveUpdateScheduler.EXTRA_START_MILLIS, startMillis)
-            putExtra(CourseLiveUpdateScheduler.EXTRA_END_MILLIS, endMillis)
-        }
-        ContextCompat.startForegroundService(context, serviceIntent)
+        AppNotificationManager.showCourseLiveUpdate(
+            courseName = courseName,
+            place = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE),
+            teacher = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_TEACHER),
+            startMillis = startMillis,
+            endMillis = endMillis,
+            contentIntent = CourseLiveUpdateScheduler.buildOpenCourseIntent(
+                context = context,
+                courseName = courseName,
+                place = intent.getStringExtra(CourseLiveUpdateScheduler.EXTRA_PLACE),
+                startMillis = startMillis,
+            ),
+        )
     }
 
     private fun finishCourseLiveUpdate(intent: Intent) {

--- a/app/src/main/res/drawable/book_24.xml
+++ b/app/src/main/res/drawable/book_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M18,2H6C4.9,2 4,2.9 4,4v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zM18,20H6V4h12v16zM8,6h8v2H8V6zM8,10h8v2H8v-2zM8,14h5v2H8v-2z" />
+</vector>

--- a/app/src/main/res/drawable/quiz_24.xml
+++ b/app/src/main/res/drawable/quiz_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M20,2H4C2.9,2 2,2.9 2,4v12c0,1.1 0.9,2 2,2h4l4,4 4,-4h4c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zM20,16h-4.83L12,19.17 8.83,16H4V4h16v12zM11,14h2v-2h-2v2zM12,6c-2.21,0 -4,1.79 -4,4h2c0,-1.1 0.9,-2 2,-2s2,0.9 2,2c0,2 -3,1.75 -3,5h2c0,-2.25 3,-2.5 3,-5 0,-2.21 -1.79,-4 -4,-4z" />
+</vector>


### PR DESCRIPTION
当前代码防护： 

1. MAX_SCHEDULED_ALARMS = 420（CourseLiveUpdateScheduler.kt:38）— take(420) 确保最多只设 420个闹钟，永远低于 500                                                                              
2. scheduleWindowChecks 已移除 —旧版那段代码会为每个课程额外创建窗口检查闹钟导致翻倍超限，当前版只通过 scheduleAll 统一调度
3. etCourseAlarm 已 catch IllegalStateException（:391-393）— 即使触及限制也只返回 false,走分批重调度，不会 crash  