### PR TITLE
bugfix-多重教务源的考试去重、刷新登录状态不刷新慧心易校（用最粗暴的方式刷新了）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,16 @@ android {
             // 启用 ABI 分割
             enable true
             reset()
-            include 'arm64-v8a',  'x86_64'
-            universalApk true
+
+            def onlyArm64Debug = project.findProperty("ONLY_ARM64_DEBUG")?.toBoolean() ?: false
+
+            if (onlyArm64Debug) {
+                include 'arm64-v8a'
+                universalApk false
+            } else {
+                include 'arm64-v8a', 'x86_64'
+                universalApk true
+            }
         }
     }
 

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/calendar/jxglstu/JxglstuCourseTableUI.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/calendar/jxglstu/JxglstuCourseTableUI.kt
@@ -256,13 +256,13 @@ fun JxglstuCourseTableUI(
                            }
                        }
                    }
-                   // 慧新易校
-                   launch huiXin@ {
-                       //检测慧新易校可用性
-                       val auth = prefs.getString("auth", "")
-                       if(auth.isNullOrEmpty()) {
-                           vm.goToHuiXin(cookies)
-                       } else {
+                    // 慧新易校
+                    launch huiXin@ {
+                        //检测慧新易校可用性
+                        val auth = prefs.getString("auth", "")
+                        if(auth.isNullOrEmpty()) {
+                            loginHuiXIn(cookies, vm)
+                        } else {
                            vm.checkHuiXinLogin(auth)
                            val result = (vm.huiXinCheckLoginResp.state.value as? UiState.Success)?.data
                            if(result == true) {

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/calendar/jxglstu/JxglstuCourseTableUI.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/calendar/jxglstu/JxglstuCourseTableUI.kt
@@ -256,27 +256,27 @@ fun JxglstuCourseTableUI(
                            }
                        }
                    }
-                   // 慧新易校
-                   launch huiXin@ {
-                       //检测慧新易校可用性
-                       val auth = prefs.getString("auth", "")
-                       if(auth.isNullOrEmpty()) {
-                           vm.goToHuiXin(cookies)
-                       } else {
-                           vm.checkHuiXinLogin(auth)
-                           val result = (vm.huiXinCheckLoginResp.state.value as? UiState.Success)?.data
-                           if(result == true) {
-                               LogUtil.debug("无需刷新慧新易校")
-                               return@huiXin
-                           } else {
-                               if(useWebVpn || GlobalStateHolder.excludeJxglstu) {
-                                   loginHuiXin(vm)
-                               } else {
-                                   loginHuiXIn(cookies,vm)
-                               }
-                           }
-                       }
-                   }
+                    // 慧新易校
+                    launch huiXin@ {
+                        //检测慧新易校可用性
+                        val auth = prefs.getString("auth", "")
+                        if(auth.isNullOrEmpty()) {
+                            loginHuiXIn(cookies, vm)
+                        } else {
+                            vm.checkHuiXinLogin(auth)
+                            val result = (vm.huiXinCheckLoginResp.state.value as? UiState.Success)?.data
+                            if(result == true) {
+                                LogUtil.debug("无需刷新慧新易校")
+                                return@huiXin
+                            } else {
+                                if(useWebVpn || GlobalStateHolder.excludeJxglstu) {
+                                    loginHuiXin(vm)
+                                } else {
+                                    loginHuiXIn(cookies,vm)
+                                }
+                            }
+                        }
+                    }
                    // 信息门户
                    launch one@ {
                        if(useWebVpn) {

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/jxglstu/exam/getExam.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/jxglstu/exam/getExam.kt
@@ -113,7 +113,18 @@ suspend fun getExamFromCache() : List<JxglstuExam> = withContext(Dispatchers.IO)
 
     // 合并并去重 优先保留信息多的，
     try {
-        (jxglstuExams + uniAppExams).groupBy { it.name to it.dateTime }
+        val examTypeSuffixes = listOf("-期中考试", "-期末考试", "-补考", "-缓考", "-重修考试", "-考试")
+        fun normalizeExam(exam: JxglstuExam): Pair<String, String> {
+            var name = exam.name.trim()
+            for (suffix in examTypeSuffixes) {
+                if (name.endsWith(suffix)) {
+                    name = name.removeSuffix(suffix)
+                    break
+                }
+            }
+            return name to exam.dateTime.trim()
+        }
+        (jxglstuExams + uniAppExams).groupBy { normalizeExam(it) }
             .map { entry ->
                 // 对每组数据按优先级（优先保留有place和type的）进行合并
                 entry.value.maxByOrNull {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ android.enableBuildConfigAsBytecode=true
 org.gradle.configuration-cache=true
 # 可选启用：Debug版本包名与Release不同
 USE_DEBUG_PACKAGE_SUFFIX=false
+# 可选启用：仅构建arm64-v8a架构的Debug版本，适用于调试阶段加快构建速度
+ONLY_ARM64_DEBUG=false


### PR DESCRIPTION
#69 #70 
# 刷新慧心易校登录状态 
在 JxglstuCourseTableUI.kt:259-278，CAS登录/刷新登录时慧心易校的刷新逻辑中：

launch huiXin@ {
    val auth = prefs.getString("auth", "")
    if(auth.isNullOrEmpty()) {
        vm.goToHuiXin(cookies)   // ← BUG: 只调用了一次
    } else {
        // ... 检查登录状态，失效后调用 loginHuiXIn(cookies, vm) (两次)
    }
}
当 auth 为空时（首次登录或 token 被清除），goToHuiXin 只调用了一次。

但同文件 124-128 行的 loginHuiXIn 函数明确注释了需要调用两次才能获得 302 重定向：

private suspend fun loginHuiXIn(cookies: String, vm: NetWorkViewModel) {
    // 也要发两次才给302
    vm.goToHuiXin(cookies)
    vm.goToHuiXin(cookies)
}
而单独点击刷新慧心易校时，走的是 loginHuiXin(vm) → huiXinSingleLogin()，直接用学号密码调用 OAuth2 token 端点，不经过 CAS 重定向，所以始终能成功。

修复
将 auth.isNullOrEmpty() 分支改为调用 loginHuiXIn：

# 两个教务源获取数据就差两个空格吗哈哈哈哈哈
<img width="1073" height="400" alt="image" src="https://github.com/user-attachments/assets/0616f811-2e67-4c16-a28e-55ba73e94886" />
