### PR TITLE
feature:学期报告

### DIFF
--- a/app/src/main/java/com/hfut/schedule/ui/nav/destination/TermReportDestination.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/nav/destination/TermReportDestination.kt
@@ -1,0 +1,21 @@
+package com.hfut.schedule.ui.nav.destination
+
+import androidx.compose.runtime.Composable
+import com.hfut.schedule.R
+import com.hfut.schedule.ui.nav.destination.base.NavDestination
+import com.hfut.schedule.ui.screen.report.TermReportScreen
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.xah.navigation.util.LocalNavDependencies
+import com.xah.common.ui.util.res
+
+object TermReportDestination : NavDestination() {
+    override val key = "term_report"
+    override val title = res(R.string.navigation_label_term_report)
+    override val icon = R.drawable.article
+
+    @Composable
+    override fun Content() {
+        val vm = LocalNavDependencies.current.get<NetWorkViewModel>()
+        TermReportScreen(vm)
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/card/count/Sheets.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/card/count/Sheets.kt
@@ -11,16 +11,20 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import com.hfut.schedule.logic.model.huixin.BillMonth
 import com.xah.common.logic.safeDiv
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 
 //消费折线图
 @Composable
-fun drawLineChart(data: List<BillMonth>) {
+fun drawLineChart(data: List<BillMonth>, modifier: Modifier = Modifier) {
+    if (data.isEmpty()) return
     val path = Path()
-    val size = Size(300f, 300f)
     val primaryColor = MaterialTheme.colorScheme.primary
-    Canvas(modifier = Modifier.size(600.dp,120.dp)) {
-        val xInterval = 30f
-        val yInterval = size.height safeDiv data.maxOf { it.balance.toFloat() }
+    Canvas(modifier = modifier.fillMaxWidth().height(120.dp)) {
+        val xInterval = if (data.size > 1) size.width / (data.size - 1) else size.width
+        val maxBalance = data.maxOf { it.balance.toFloat() }
+        val yInterval = if (maxBalance > 0) size.height / maxBalance else 0f
+        
         path.moveTo(0f, size.height - data.first().balance.toFloat() * yInterval)
         data.forEachIndexed { index, pair ->
             val x = index * xInterval

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/SearchUI.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/SearchUI.kt
@@ -79,6 +79,7 @@ import com.hfut.schedule.ui.nav.destination.WebViewDestination
 import com.hfut.schedule.ui.nav.destination.WebVpnDestination
 import com.hfut.schedule.ui.nav.destination.WorkAndRestDestination
 import com.hfut.schedule.ui.nav.destination.WorkDestination
+import com.hfut.schedule.ui.nav.destination.TermReportDestination
 import com.hfut.schedule.ui.nav.window.ExpressWindow
 import com.hfut.schedule.ui.nav.window.FeedbackWindow
 import com.hfut.schedule.ui.nav.window.RepairWindow
@@ -132,6 +133,7 @@ import com.hfut.schedule.ui.screen.home.search.function.school.student.ToadyCamp
 import com.hfut.schedule.ui.screen.home.search.function.school.teacherSearch.TeacherSearch
 import com.hfut.schedule.ui.screen.home.search.function.school.webvpn.WebVpn
 import com.hfut.schedule.ui.screen.home.search.function.school.work.Work
+import com.hfut.schedule.ui.screen.home.search.function.report.TermReport
 import com.hfut.schedule.ui.style.color.textFiledTransplant
 import com.hfut.schedule.ui.util.state.GlobalStateHolder
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
@@ -256,6 +258,7 @@ fun SearchScreen(
                 SearchAppBean(48,"事务跟踪 事务追踪 issue 反馈 开发 ${context.getString(R.string.navigation_label_track)}", { Track() }, TrackDestination.key),
                 SearchAppBean(49,"拼多多 淘宝 快递 取件码 包裹 ${context.getString(R.string.navigation_label_express)}", { Express() },ExpressWindow.key),
                 SearchAppBean(50,"${context.getString(R.string.navigation_label_feedback)} 反馈 建议", { Feedback() }, FeedbackWindow.key),
+                SearchAppBean(51,"${TermReportDestination.title.asString(context)} 学期总结 成绩 消费 图书馆 借阅 统计 报表", { TermReport() }, TermReportDestination.key),
             )
         )
     }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/report/TermReport.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/report/TermReport.kt
@@ -1,0 +1,31 @@
+package com.hfut.schedule.ui.screen.home.search.function.report
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.nav.destination.TermReportDestination
+import com.xah.navigation.util.LocalNavController
+import com.xah.common.ui.component.text.ScrollText
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@SuppressLint("SuspiciousIndentation")
+@Composable
+fun TermReport() {
+    val navController = LocalNavController.current
+    TransplantListItem(
+        headlineContent = {
+            ScrollText(text = TermReportDestination.title.asString())
+        },
+        leadingContent = {
+            Icon(painterResource(TermReportDestination.icon), contentDescription = null)
+        },
+        modifier = Modifier.clickable {
+            navController.push(TermReportDestination)
+        }
+    )
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -2,7 +2,9 @@ package com.hfut.schedule.ui.screen.report
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,8 +26,12 @@ import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
 import com.hfut.schedule.ui.component.container.CustomCard
 import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.component.container.cardNormalColor
+import androidx.compose.foundation.layout.Row
 import com.hfut.schedule.ui.component.network.CommonNetworkScreen
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.xah.common.ui.component.chart.BarChart
+import com.xah.common.ui.component.chart.RadarChart
+import com.xah.common.ui.component.chart.RadarData
 import com.hfut.schedule.ui.screen.home.search.function.jxglstu.exam.JxglstuExam
 import com.hfut.schedule.ui.screen.home.search.function.jxglstu.exam.getExamFromCache
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
@@ -46,6 +52,29 @@ private data class ExamAnalysisResult(
     val consecutiveEnd: LocalDate?
 )
 
+private fun gradeTextToDouble(grade: String): Double? {
+    return grade.toDoubleOrNull() ?: when (grade) {
+        "优" -> 3.9
+        "良" -> 3.0
+        "中" -> 2.0
+        "及格" -> 1.2
+        "不及格" -> 0.0
+        else -> null
+    }
+}
+
+private fun gradeDisplayText(grade: String?, credits: Double): String {
+    if (grade == null) return "${credits}学分"
+    val numeric = grade.toDoubleOrNull()
+    return if (numeric != null) {
+        "${formatDecimal(numeric, 1)}分 / ${credits}学分"
+    } else {
+        val mapped = gradeTextToDouble(grade)
+        if (mapped != null) "$grade (${formatDecimal(mapped, 1)}) / ${credits}学分"
+        else "$grade / ${credits}学分"
+    }
+}
+
 @Composable
 fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     val uiState by vm.uniAppGradesResp.state.collectAsState()
@@ -56,21 +85,24 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     LaunchedEffect(semester) {
         courseAnalysis = null
         try {
-            val targetSemester = if (semester == 0) SemesterParser.getSemester() else semester
-            val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(targetSemester))
-            if (json != null) {
-                val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
-                val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
-                for (item in courses) {
-                    for (schedule in item.schedules) {
-                        weekCount.getOrPut(schedule.weekIndex) { mutableListOf() }
-                            .add(item.course.nameZh to "${schedule.startTime}-${schedule.endTime}")
+            val currentSem = SemesterParser.getSemester()
+            // 只有在全部学期(0)或者当前学期时，才展示课表分析（因为本地只缓存了当前学期的课表）
+            if (semester == 0 || semester == currentSem || semester == SemesterParser.getSemesterWithoutSuspend()) {
+                val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(currentSem))
+                if (json != null) {
+                    val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
+                    val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
+                    for (item in courses) {
+                        for (schedule in item.schedules) {
+                            weekCount.getOrPut(schedule.weekIndex) { mutableListOf() }
+                                .add(item.course.nameZh to "${schedule.startTime}-${schedule.endTime}")
+                        }
                     }
-                }
-                if (weekCount.isNotEmpty()) {
-                    val busiest = weekCount.maxByOrNull { it.value.size }!!
-                    val avg = weekCount.values.sumOf { it.size }.toDouble() / weekCount.size
-                    courseAnalysis = CourseAnalysisResult(busiest.key, busiest.value, avg)
+                    if (weekCount.isNotEmpty()) {
+                        val busiest = weekCount.maxByOrNull { it.value.size }!!
+                        val avg = weekCount.values.sumOf { it.size }.toDouble() / weekCount.size
+                        courseAnalysis = CourseAnalysisResult(busiest.key, busiest.value, avg)
+                    }
                 }
             }
         } catch (_: Exception) {}
@@ -142,32 +174,32 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(headlineContent = { Text("暂无成绩数据") })
                 }
-                return@CommonNetworkScreen
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+            } else {
+                // 最佳和最差科目
+                val sorted = remember(grades) { grades.sortedByDescending { it.gp } }
+                val best = sorted.first()
+                val worst = sorted.last()
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
+                        headlineContent = { Text("科目排行", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("最佳科目") },
+                        headlineContent = { Text(best.courseNameZh, style = MaterialTheme.typography.titleSmall) },
+                        trailingContent = { Text(gradeDisplayText(best.finalGrade, best.credits)) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("最差科目") },
+                        headlineContent = { Text(worst.courseNameZh, style = MaterialTheme.typography.titleSmall) },
+                        trailingContent = { Text(gradeDisplayText(worst.finalGrade, worst.credits)) }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
             }
-
-            // 最佳和最差科目
-            val sorted = remember(grades) { grades.filter { it.finalGrade != null }.sortedByDescending { it.finalGrade!!.toDoubleOrNull() ?: 0.0 } }
-            val best = sorted.first()
-            val worst = sorted.last()
-
-            CustomCard(color = cardNormalColor()) {
-                TransplantListItem(
-                    overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
-                    headlineContent = { Text("科目排行", style = MaterialTheme.typography.titleMedium) }
-                )
-                TransplantListItem(
-                    overlineContent = { Text("最佳科目 ${formatDecimal(best.finalGrade!!.toDoubleOrNull() ?: 0.0, 1)}分") },
-                    headlineContent = { Text(best.courseNameZh, style = MaterialTheme.typography.titleSmall) },
-                    trailingContent = { Text("${best.credits}学分") }
-                )
-                TransplantListItem(
-                    overlineContent = { Text("最差科目 ${formatDecimal(worst.finalGrade!!.toDoubleOrNull() ?: 0.0, 1)}分") },
-                    headlineContent = { Text(worst.courseNameZh, style = MaterialTheme.typography.titleSmall) },
-                    trailingContent = { Text("${worst.credits}学分") }
-                )
-            }
-
-            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
             // 课表分析：最繁忙周
             courseAnalysis?.let { (busiestWeekNum, busiestCourses, avgPerWeek) ->
@@ -175,8 +207,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        overlineContent = { Text("课表分析") },
-                        headlineContent = { Text("最繁忙的一周", style = MaterialTheme.typography.titleMedium) }
+                        headlineContent = { Text("🚀 最繁忙的一周", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     TransplantListItem(
                         overlineContent = { Text("第${busiestWeekNum}周") },
@@ -199,8 +230,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
             examAnalysis?.let { result ->
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        overlineContent = { Text("考试分析") },
-                        headlineContent = { Text("考试月份分布", style = MaterialTheme.typography.titleMedium) }
+                        headlineContent = { Text("📅 考试月分布", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     result.busiestMonth?.let { (month, exams) ->
                         TransplantListItem(
@@ -229,85 +259,93 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
             }
 
-            // 学分分布
-            val creditGroups = remember(grades) {
-                grades.groupBy { it.credits.toInt() }
-                    .mapValues { (_, v) -> v.size }
-                    .toList().sortedByDescending { it.first }
-            }
-
-            CustomCard(color = cardNormalColor()) {
-                TransplantListItem(
-                    overlineContent = { Text("学分分布") },
-                    headlineContent = { Text("各学分课程数量", style = MaterialTheme.typography.titleMedium) }
-                )
-                creditGroups.forEach { (credit, count) ->
-                    if (credit > 0) {
-                        TransplantListItem(
-                            headlineContent = { Text("${credit}学分课程") },
-                            trailingContent = { Text("${count}门") }
-                        )
+            if (grades.isNotEmpty()) {
+                // 学分分布 BarChart
+                val creditGroups = remember(grades) {
+                    grades.groupBy { it.credits.toInt() }
+                        .mapValues { (_, v) -> v.size }
+                        .toList().sortedByDescending { it.first }
+                }
+                
+                // GPA分布 BarChart
+                val gpaRanges = remember(grades) {
+                    val ranges = listOf(
+                        "4.0+" to { g: Double -> g >= 4.0 },
+                        "3.5-3.9" to { g: Double -> g in 3.5..3.99 },
+                        "3.0-3.4" to { g: Double -> g in 3.0..3.49 },
+                        "2.0-2.9" to { g: Double -> g in 2.0..2.99 },
+                        "< 2.0" to { g: Double -> g < 2.0 }
+                    )
+                    ranges.mapNotNull { (label, filter) ->
+                        val count = grades.count { filter(it.gp) }
+                        if (count > 0) label to count else null
                     }
                 }
-            }
 
-            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
-            // GPA分布
-            val gpaRanges = remember(grades) {
-                val ranges = listOf(
-                    "4.0+" to { g: Double -> g >= 4.0 },
-                    "3.5-4.0" to { g: Double -> g in 3.5..3.99 },
-                    "3.0-3.5" to { g: Double -> g in 3.0..3.49 },
-                    "2.0-3.0" to { g: Double -> g in 2.0..2.99 },
-                    "2.0以下" to { g: Double -> g < 2.0 }
-                )
-                ranges.mapNotNull { (label, filter) ->
-                    val count = grades.count { (it.gp).let { g -> filter(g) } }
-                    if (count > 0) label to count else null
+                // 课程类别能力雷达图 (按单科绩点)
+                val radarData = remember(grades) {
+                    val targetGrades = if (grades.size > 8) grades.sortedByDescending { it.credits }.take(8) else grades
+                    targetGrades.map { 
+                        val ratio = (it.gp / 4.0f).toFloat().coerceIn(0f, 1f)
+                        RadarData(it.courseNameZh.take(4), ratio) 
+                    }
                 }
-            }
 
-            CustomCard(color = cardNormalColor()) {
-                TransplantListItem(
-                    overlineContent = { Text("绩点分布") },
-                    headlineContent = { Text("GPA 分布统计", style = MaterialTheme.typography.titleMedium) }
-                )
-                gpaRanges.forEach { (range, count) ->
+                CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        headlineContent = { Text("GPA $range") },
-                        trailingContent = { Text("${count}门") }
+                        headlineContent = { Text("📊 学业数据图表", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                    )
+                    
+                    if (radarData.size >= 3) {
+                        TransplantListItem(headlineContent = { Text("各科绩点能力模型", style = MaterialTheme.typography.titleSmall) })
+                        RadarChart(
+                            data = radarData,
+                            modifier = Modifier.fillMaxWidth().height(220.dp).padding(16.dp)
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+
+                    if (creditGroups.isNotEmpty()) {
+                        val barData = creditGroups.associate { "${it.first}学分" to it.second.toFloat() }
+                        BarChart(data = barData, showLabel = true, title = "学分分布", modifier = Modifier.padding(bottom = 16.dp))
+                    }
+                    
+                    if (gpaRanges.isNotEmpty()) {
+                        val gpaBarData = gpaRanges.associate { it.first to it.second.toFloat() }
+                        BarChart(data = gpaBarData, showLabel = true, title = "绩点分布", modifier = Modifier.padding(bottom = 16.dp))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 有趣统计
+                val messages = remember(grades) {
+                    mutableListOf<String>().apply {
+                        val totalCredits = grades.sumOf { it.credits }
+                        val avgGp = grades.map { it.gp }.average()
+                        val highGpa = grades.count { it.gp >= 4.0 }
+                        val perfect = grades.count { val score = it.finalGrade?.toDoubleOrNull(); score != null && score >= 95.0 }
+                        val nearFail = grades.count { val score = it.finalGrade?.toDoubleOrNull(); score != null && score in 60.0..65.0 }
+
+                        add("本学期共修 ${grades.size} 门课程，总计 ${formatDecimal(totalCredits, 1)} 学分")
+                        add("平均绩点 ${formatDecimal(avgGp, 2)}")
+                        if (highGpa > 0) add("其中 $highGpa 门课程 GPA ≥ 4.0，学霸认证！")
+                        if (perfect > 0) add("有 $perfect 门课程 ≥ 95 分，接近满分！")
+                        if (nearFail > 0) add("有 $nearFail 门课程在 60-65 分之间，险过！")
+                        if (avgGp >= 3.5) add("整体表现优秀，继续保持！")
+                        else if (avgGp >= 3.0) add("表现不错，还有提升空间~")
+                        else add("革命尚未成功，同志仍需努力！")
+                    }
+                }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        headlineContent = { Text("💡 学期总结", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                    )
+                    TransplantListItem(
+                        headlineContent = { Text(messages.joinToString("\n"), style = MaterialTheme.typography.bodyMedium) }
                     )
                 }
-            }
-
-            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
-            // 有趣统计
-            val messages = remember(grades) {
-                mutableListOf<String>().apply {
-                    val totalCredits = grades.sumOf { it.credits }
-                    val avgGp = grades.map { it.gp }.average()
-                    val highGpa = grades.count { it.gp >= 4.0 }
-                    val perfect = grades.count { (it.finalGrade?.toDoubleOrNull() ?: 0.0) >= 95.0 }
-                    val nearFail = grades.count { (it.finalGrade?.toDoubleOrNull() ?: 0.0) in 60.0..65.0 }
-
-                    add("本学期共修 ${grades.size} 门课程，总计 ${formatDecimal(totalCredits, 1)} 学分")
-                    add("平均绩点 ${formatDecimal(avgGp, 2)}")
-                    if (highGpa > 0) add("其中 $highGpa 门课程 GPA ≥ 4.0，学霸认证！")
-                    if (perfect > 0) add("有 $perfect 门课程 ≥ 95 分，接近满分！")
-                    if (nearFail > 0) add("有 $nearFail 门课程在 60-65 分之间，险过！")
-                    if (avgGp >= 3.5) add("整体表现优秀，继续保持！")
-                    else if (avgGp >= 3.0) add("表现不错，还有提升空间~")
-                    else add("革命尚未成功，同志仍需努力！")
-                }
-            }
-
-            CustomCard(color = cardNormalColor()) {
-                TransplantListItem(
-                    overlineContent = { Text("学期总结") },
-                    headlineContent = { Text(messages.joinToString("\n"), style = MaterialTheme.typography.bodyMedium) }
-                )
             }
             }
         }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -80,29 +80,25 @@ private fun gradeDisplayText(grade: String?, credits: Double): String {
 fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     val uiState by vm.uniAppGradesResp.state.collectAsState()
 
-    val currentSem = remember { SemesterParser.getSemesterWithoutSuspend() }
-
+    val defaultSem = remember { semester }
     var courseAnalysis by remember { mutableStateOf<CourseAnalysisResult?>(null) }
 
-    LaunchedEffect(semester) {
-        courseAnalysis = null
+    LaunchedEffect(Unit) {
         try {
-            if (semester == 0 || semester == currentSem) {
-                val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(SemesterParser.getSemester()))
-                if (json != null) {
-                    val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
-                    val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
-                    for (item in courses) {
-                        for (schedule in item.schedules) {
-                            weekCount.getOrPut(schedule.weekIndex) { mutableListOf() }
-                                .add(item.course.nameZh to "${schedule.startTime}-${schedule.endTime}")
-                        }
+            val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(SemesterParser.getSemester()))
+            if (json != null) {
+                val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
+                val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
+                for (item in courses) {
+                    for (schedule in item.schedules) {
+                        weekCount.getOrPut(schedule.weekIndex) { mutableListOf() }
+                            .add(item.course.nameZh to "${schedule.startTime}-${schedule.endTime}")
                     }
-                    if (weekCount.isNotEmpty()) {
-                        val busiest = weekCount.maxByOrNull { it.value.size }!!
-                        val avg = weekCount.values.sumOf { it.size }.toDouble() / weekCount.size
-                        courseAnalysis = CourseAnalysisResult(busiest.key, busiest.value, avg)
-                    }
+                }
+                if (weekCount.isNotEmpty()) {
+                    val busiest = weekCount.maxByOrNull { it.value.size }!!
+                    val avg = weekCount.values.sumOf { it.size }.toDouble() / weekCount.size
+                    courseAnalysis = CourseAnalysisResult(busiest.key, busiest.value, avg)
                 }
             }
         } catch (_: Exception) {}
@@ -216,29 +212,31 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
             }
 
-            // 课表分析：最繁忙周
-            courseAnalysis?.let { (busiestWeekNum, busiestCourses, avgPerWeek) ->
-                val courseNames = busiestCourses.map { it.first }.distinct()
+            // 课表分析：最繁忙周（仅默认学期可见）
+            if (semester == defaultSem) {
+                courseAnalysis?.let { (busiestWeekNum, busiestCourses, avgPerWeek) ->
+                    val courseNames = busiestCourses.map { it.first }.distinct()
 
-                CustomCard(color = cardNormalColor()) {
-                    TransplantListItem(
-                        headlineContent = { Text("最繁忙的一周", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("第${busiestWeekNum}周") },
-                        headlineContent = { Text("共 ${busiestCourses.size} 节课", style = MaterialTheme.typography.headlineMedium) },
-                        supportingContent = { Text("平均每周 ${formatDecimal(avgPerWeek, 1)} 节") }
-                    )
-                    val courseListStr = buildString {
-                        append(courseNames.take(6).joinToString("\n"))
-                        if (courseNames.size > 6) {
-                            append("\n...还有 ${courseNames.size - 6} 门课")
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            headlineContent = { Text("最繁忙的一周", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                        )
+                        TransplantListItem(
+                            overlineContent = { Text("第${busiestWeekNum}周") },
+                            headlineContent = { Text("共 ${busiestCourses.size} 节课", style = MaterialTheme.typography.headlineMedium) },
+                            supportingContent = { Text("平均每周 ${formatDecimal(avgPerWeek, 1)} 节") }
+                        )
+                        val courseListStr = buildString {
+                            append(courseNames.take(6).joinToString("\n"))
+                            if (courseNames.size > 6) {
+                                append("\n...还有 ${courseNames.size - 6} 门课")
+                            }
                         }
+                        TransplantListItem(headlineContent = { Text(courseListStr, style = MaterialTheme.typography.bodyMedium) })
                     }
-                    TransplantListItem(headlineContent = { Text(courseListStr, style = MaterialTheme.typography.bodyMedium) })
-                }
 
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
             }
 
             // 考试分析

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -79,16 +80,15 @@ private fun gradeDisplayText(grade: String?, credits: Double): String {
 fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     val uiState by vm.uniAppGradesResp.state.collectAsState()
 
+    val currentSem = remember { SemesterParser.getSemesterWithoutSuspend() }
+
     var courseAnalysis by remember { mutableStateOf<CourseAnalysisResult?>(null) }
-    var examAnalysis by remember { mutableStateOf<ExamAnalysisResult?>(null) }
 
     LaunchedEffect(semester) {
         courseAnalysis = null
         try {
-            val currentSem = SemesterParser.getSemester()
-            // 只有在全部学期(0)或者当前学期时，才展示课表分析（因为本地只缓存了当前学期的课表）
-            if (semester == 0 || semester == currentSem || semester == SemesterParser.getSemesterWithoutSuspend()) {
-                val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(currentSem))
+            if (semester == 0 || semester == currentSem) {
+                val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(SemesterParser.getSemester()))
                 if (json != null) {
                     val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
                     val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
@@ -108,8 +108,8 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
         } catch (_: Exception) {}
     }
 
-    LaunchedEffect(semester) {
-        examAnalysis = null
+    val examAnalysis by produceState<ExamAnalysisResult?>(initialValue = null, semester) {
+        value = null
         try {
             val allExams = getExamFromCache()
             val termInfo = parseSemesterInt(semester)
@@ -119,41 +119,56 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 allExams.filter { exam ->
                     try {
                         val date = exam.dateTime.substring(0, 10)
-                        date >= start && date < end
+                        date in start..<end
                     } catch (_: Exception) { false }
                 }
             }
-            
-            if (exams.isNotEmpty()) {
-                val monthGroups = exams.groupBy { exam ->
-                    try { exam.dateTime.substring(0, 7) } catch (_: Exception) { "未知" }
-                }
-                val dates = exams.mapNotNull { exam ->
-                    try { LocalDate.parse(exam.dateTime.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE) }
-                    catch (_: Exception) { null }
-                }.sorted()
 
-                var maxCons = 1; var curCons = 1
-                var maxStart = dates.firstOrNull(); var maxEnd = dates.firstOrNull()
-                var tempStart = dates.firstOrNull()
-                for (i in 1 until dates.size) {
-                    if (dates[i].toEpochDay() - dates[i - 1].toEpochDay() == 1L) {
-                        curCons++
-                    } else {
-                        if (curCons > maxCons) { maxCons = curCons; maxStart = tempStart; maxEnd = dates[i - 1] }
-                        curCons = 1; tempStart = dates[i]
-                    }
-                }
-                if (curCons > maxCons) { maxCons = curCons; maxStart = tempStart; maxEnd = dates.last() }
+            if (exams.isNotEmpty()) {
+                val monthGroups = exams.groupBy {
+                    try {
+                        it.dateTime.substring(5, 7).toInt()
+                    } catch (_: Exception) { 0 }
+                }.filterKeys { it != 0 }
 
                 val busiestMonthEntry = monthGroups.maxByOrNull { it.value.size }
-                val busiestMonth = busiestMonthEntry?.let { it.key to it.value }
-                val monthStats = monthGroups.map { (m, l) -> m to l.size }.sortedByDescending { it.second }
-                examAnalysis = ExamAnalysisResult(busiestMonth, monthStats, maxCons, maxStart, maxEnd)
-            } else {
-                examAnalysis = null
+                val busiestMonth = busiestMonthEntry?.let { it.key.toString() to it.value }
+
+                val monthStats = monthGroups.map { it.key.toString() to it.value.size }.sortedBy { it.first.toInt() }
+
+                val sortedDates = exams.mapNotNull {
+                    try {
+                        LocalDate.parse(it.dateTime.substring(0, 10))
+                    } catch (_: Exception) { null }
+                }.sorted().distinct()
+
+                var maxCons = 1
+                var currentCons = 1
+                var maxStart: LocalDate? = sortedDates.firstOrNull()
+                var maxEnd: LocalDate? = sortedDates.firstOrNull()
+                var currentStart: LocalDate? = sortedDates.firstOrNull()
+
+                for (i in 1 until sortedDates.size) {
+                    val prev = sortedDates[i - 1]
+                    val curr = sortedDates[i]
+                    if (prev.plusDays(1) == curr) {
+                        currentCons++
+                        if (currentCons > maxCons) {
+                            maxCons = currentCons
+                            maxStart = currentStart
+                            maxEnd = curr
+                        }
+                    } else {
+                        currentCons = 1
+                        currentStart = curr
+                    }
+                }
+
+                value = ExamAnalysisResult(busiestMonth, monthStats, maxCons, maxStart, maxEnd)
             }
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     DividerTextExpandedWith("学业分析", false) {
@@ -207,7 +222,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        headlineContent = { Text("🚀 最繁忙的一周", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                        headlineContent = { Text("最繁忙的一周", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     TransplantListItem(
                         overlineContent = { Text("第${busiestWeekNum}周") },
@@ -230,7 +245,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
             examAnalysis?.let { result ->
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        headlineContent = { Text("📅 考试月分布", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                        headlineContent = { Text("考试月分布", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     result.busiestMonth?.let { (month, exams) ->
                         TransplantListItem(
@@ -293,7 +308,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        headlineContent = { Text("📊 学业数据图表", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                        headlineContent = { Text("学业数据图表", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     
                     if (radarData.size >= 3) {
@@ -340,7 +355,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        headlineContent = { Text("💡 学期总结", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
+                        headlineContent = { Text("学期总结", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.primary) }
                     )
                     TransplantListItem(
                         headlineContent = { Text(messages.joinToString("\n"), style = MaterialTheme.typography.bodyMedium) }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -54,6 +54,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     var examAnalysis by remember { mutableStateOf<ExamAnalysisResult?>(null) }
 
     LaunchedEffect(semester) {
+        courseAnalysis = null
         try {
             val targetSemester = if (semester == 0) SemesterParser.getSemester() else semester
             val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(targetSemester))
@@ -76,6 +77,7 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     }
 
     LaunchedEffect(semester) {
+        examAnalysis = null
         try {
             val allExams = getExamFromCache()
             val termInfo = parseSemesterInt(semester)

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -1,0 +1,302 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.gson.Gson
+import com.hfut.schedule.logic.model.uniapp.UniAppCoursesResponse
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.parse.SemesterParser
+import com.hfut.schedule.logic.util.parse.formatDecimal
+import com.hfut.schedule.logic.util.storage.file.LargeStringDataManager
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.network.CommonNetworkScreen
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.ui.screen.home.search.function.jxglstu.exam.JxglstuExam
+import com.hfut.schedule.ui.screen.home.search.function.jxglstu.exam.getExamFromCache
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+private data class CourseAnalysisResult(
+    val busiestWeekNum: Int,
+    val busiestCourses: List<Pair<String, String>>,
+    val avgPerWeek: Double
+)
+
+private data class ExamAnalysisResult(
+    val busiestMonth: Pair<String, List<JxglstuExam>>?,
+    val monthStats: List<Pair<String, Int>>,
+    val maxConsecutiveDays: Int,
+    val consecutiveStart: LocalDate?,
+    val consecutiveEnd: LocalDate?
+)
+
+@Composable
+fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
+    val uiState by vm.uniAppGradesResp.state.collectAsState()
+
+    var courseAnalysis by remember { mutableStateOf<CourseAnalysisResult?>(null) }
+    var examAnalysis by remember { mutableStateOf<ExamAnalysisResult?>(null) }
+
+    LaunchedEffect(semester) {
+        try {
+            val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(SemesterParser.getSemester()))
+            if (json != null) {
+                val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
+                val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
+                for (item in courses) {
+                    for (schedule in item.schedules) {
+                        weekCount.getOrPut(schedule.weekIndex) { mutableListOf() }
+                            .add(item.course.nameZh to "${schedule.startTime}-${schedule.endTime}")
+                    }
+                }
+                if (weekCount.isNotEmpty()) {
+                    val busiest = weekCount.maxByOrNull { it.value.size }!!
+                    val avg = weekCount.values.sumOf { it.size }.toDouble() / weekCount.size
+                    courseAnalysis = CourseAnalysisResult(busiest.key, busiest.value, avg)
+                }
+            }
+        } catch (_: Exception) {}
+    }
+
+    LaunchedEffect(semester) {
+        try {
+            val exams = getExamFromCache()
+            if (exams.isNotEmpty()) {
+                val monthGroups = exams.groupBy { exam ->
+                    try { exam.dateTime.substring(0, 7) } catch (_: Exception) { "未知" }
+                }
+                val dates = exams.mapNotNull { exam ->
+                    try { LocalDate.parse(exam.dateTime.substring(0, 10), DateTimeFormatter.ISO_LOCAL_DATE) }
+                    catch (_: Exception) { null }
+                }.sorted()
+
+                var maxCons = 1; var curCons = 1
+                var maxStart = dates.firstOrNull(); var maxEnd = dates.firstOrNull()
+                var tempStart = dates.firstOrNull()
+                for (i in 1 until dates.size) {
+                    if (dates[i].toEpochDay() - dates[i - 1].toEpochDay() == 1L) {
+                        curCons++
+                    } else {
+                        if (curCons > maxCons) { maxCons = curCons; maxStart = tempStart; maxEnd = dates[i - 1] }
+                        curCons = 1; tempStart = dates[i]
+                    }
+                }
+                if (curCons > maxCons) { maxCons = curCons; maxStart = tempStart; maxEnd = dates.last() }
+
+                val busiestMonthEntry = monthGroups.maxByOrNull { it.value.size }
+                val busiestMonth = busiestMonthEntry?.let { it.key to it.value }
+                val monthStats = monthGroups.map { (m, l) -> m to l.size }.sortedByDescending { it.second }
+                examAnalysis = ExamAnalysisResult(busiestMonth, monthStats, maxCons, maxStart, maxEnd)
+            }
+        } catch (_: Exception) {}
+    }
+
+    DividerTextExpandedWith("学业分析", false) {
+        CommonNetworkScreen(uiState, onReload = null) {
+            val gradeMap = (uiState as UiState.Success).data
+            val termInfo = parseSemesterInt(semester)
+
+            val grades = remember(gradeMap, semester) {
+                if (termInfo == null || semester == 0) {
+                    gradeMap.values.flatten().filter { it.finalGrade != null }
+                } else {
+                    gradeMap.filter { termStringToSemesterInt(it.key) == semester }.values.flatten().filter { it.finalGrade != null }
+                }
+            }
+
+            if (grades.isEmpty()) {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("暂无成绩数据") })
+                }
+                return@CommonNetworkScreen
+            }
+
+            // 最佳和最差科目
+            val sorted = remember(grades) { grades.filter { it.finalGrade != null }.sortedByDescending { it.finalGrade!!.toDoubleOrNull() ?: 0.0 } }
+            val best = sorted.first()
+            val worst = sorted.last()
+
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
+                    headlineContent = { Text("科目排行", style = MaterialTheme.typography.titleMedium) }
+                )
+                TransplantListItem(
+                    overlineContent = { Text("最佳科目 ${formatDecimal(best.finalGrade!!.toDoubleOrNull() ?: 0.0, 1)}分") },
+                    headlineContent = { Text(best.courseNameZh, style = MaterialTheme.typography.titleSmall) },
+                    trailingContent = { Text("${best.credits}学分") }
+                )
+                TransplantListItem(
+                    overlineContent = { Text("最差科目 ${formatDecimal(worst.finalGrade!!.toDoubleOrNull() ?: 0.0, 1)}分") },
+                    headlineContent = { Text(worst.courseNameZh, style = MaterialTheme.typography.titleSmall) },
+                    trailingContent = { Text("${worst.credits}学分") }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+            // 课表分析：最繁忙周
+            courseAnalysis?.let { (busiestWeekNum, busiestCourses, avgPerWeek) ->
+                val courseNames = busiestCourses.map { it.first }.distinct()
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("课表分析") },
+                        headlineContent = { Text("最繁忙的一周", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("第${busiestWeekNum}周") },
+                        headlineContent = { Text("共 ${busiestCourses.size} 节课", style = MaterialTheme.typography.headlineMedium) },
+                        supportingContent = { Text("平均每周 ${formatDecimal(avgPerWeek, 1)} 节") }
+                    )
+                    courseNames.take(6).forEach { name ->
+                        TransplantListItem(headlineContent = { Text(name, style = MaterialTheme.typography.bodyMedium) })
+                    }
+                    if (courseNames.size > 6) {
+                        TransplantListItem(headlineContent = { Text("...还有 ${courseNames.size - 6} 门课", style = MaterialTheme.typography.bodySmall) })
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+            }
+
+            // 考试分析
+            examAnalysis?.let { result ->
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("考试分析") },
+                        headlineContent = { Text("考试月份分布", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    result.busiestMonth?.let { (month, exams) ->
+                        TransplantListItem(
+                            overlineContent = { Text("考试最多的月份") },
+                            headlineContent = { Text("${month}月", style = MaterialTheme.typography.headlineMedium) },
+                            supportingContent = { Text("共 ${exams.size} 门考试") }
+                        )
+                    }
+                    result.monthStats.forEach { (month, count) ->
+                        TransplantListItem(
+                            headlineContent = { Text("${month}月") },
+                            trailingContent = { Text("${count}门") }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                if (result.maxConsecutiveDays >= 2 && result.consecutiveStart != null && result.consecutiveEnd != null) {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("连续考试") },
+                            headlineContent = { Text("最长连续考试 ${result.maxConsecutiveDays} 天", style = MaterialTheme.typography.titleMedium) },
+                            supportingContent = {
+                                Text("${result.consecutiveStart.format(DateTimeFormatter.ofPattern("M月d日"))} ~ ${result.consecutiveEnd.format(DateTimeFormatter.ofPattern("M月d日"))}")
+                            }
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+            }
+
+            // 学分分布
+            val creditGroups = remember(grades) {
+                grades.groupBy { it.credits.toInt() }
+                    .mapValues { (_, v) -> v.size }
+                    .toList().sortedByDescending { it.first }
+            }
+
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    overlineContent = { Text("学分分布") },
+                    headlineContent = { Text("各学分课程数量", style = MaterialTheme.typography.titleMedium) }
+                )
+                creditGroups.forEach { (credit, count) ->
+                    if (credit > 0) {
+                        TransplantListItem(
+                            headlineContent = { Text("${credit}学分课程") },
+                            trailingContent = { Text("${count}门") }
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+            // GPA分布
+            val gpaRanges = remember(grades) {
+                val ranges = listOf(
+                    "4.0+" to { g: Double -> g >= 4.0 },
+                    "3.5-4.0" to { g: Double -> g in 3.5..3.99 },
+                    "3.0-3.5" to { g: Double -> g in 3.0..3.49 },
+                    "2.0-3.0" to { g: Double -> g in 2.0..2.99 },
+                    "2.0以下" to { g: Double -> g < 2.0 }
+                )
+                ranges.mapNotNull { (label, filter) ->
+                    val count = grades.count { (it.gp).let { g -> filter(g) } }
+                    if (count > 0) label to count else null
+                }
+            }
+
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    overlineContent = { Text("绩点分布") },
+                    headlineContent = { Text("GPA 分布统计", style = MaterialTheme.typography.titleMedium) }
+                )
+                gpaRanges.forEach { (range, count) ->
+                    TransplantListItem(
+                        headlineContent = { Text("GPA $range") },
+                        trailingContent = { Text("${count}门") }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+            // 有趣统计
+            val messages = remember(grades) {
+                mutableListOf<String>().apply {
+                    val totalCredits = grades.sumOf { it.credits }
+                    val avgGp = grades.map { it.gp }.average()
+                    val highGpa = grades.count { it.gp >= 4.0 }
+                    val perfect = grades.count { (it.finalGrade?.toDoubleOrNull() ?: 0.0) >= 95.0 }
+                    val nearFail = grades.count { (it.finalGrade?.toDoubleOrNull() ?: 0.0) in 60.0..65.0 }
+
+                    add("本学期共修 ${grades.size} 门课程，总计 ${formatDecimal(totalCredits, 1)} 学分")
+                    add("平均绩点 ${formatDecimal(avgGp, 2)}")
+                    if (highGpa > 0) add("其中 $highGpa 门课程 GPA ≥ 4.0，学霸认证！")
+                    if (perfect > 0) add("有 $perfect 门课程 ≥ 95 分，接近满分！")
+                    if (nearFail > 0) add("有 $nearFail 门课程在 60-65 分之间，险过！")
+                    if (avgGp >= 3.5) add("整体表现优秀，继续保持！")
+                    else if (avgGp >= 3.0) add("表现不错，还有提升空间~")
+                    else add("革命尚未成功，同志仍需努力！")
+                }
+            }
+
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    overlineContent = { Text("学期总结") },
+                    headlineContent = {}
+                )
+                messages.forEach { msg ->
+                    TransplantListItem(headlineContent = { Text(msg, style = MaterialTheme.typography.bodyMedium) })
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicAnalysisSection.kt
@@ -1,5 +1,6 @@
 package com.hfut.schedule.ui.screen.report
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
@@ -54,7 +55,8 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
     LaunchedEffect(semester) {
         try {
-            val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(SemesterParser.getSemester()))
+            val targetSemester = if (semester == 0) SemesterParser.getSemester() else semester
+            val json = LargeStringDataManager.read(LargeStringDataManager.getUniAppCoursesKey(targetSemester))
             if (json != null) {
                 val courses = Gson().fromJson(json, UniAppCoursesResponse::class.java).data
                 val weekCount = mutableMapOf<Int, MutableList<Pair<String, String>>>()
@@ -75,7 +77,19 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
     LaunchedEffect(semester) {
         try {
-            val exams = getExamFromCache()
+            val allExams = getExamFromCache()
+            val termInfo = parseSemesterInt(semester)
+            val exams = if (termInfo == null || semester == 0) allExams else {
+                val start = termInfo.dateRangeStart
+                val end = termInfo.dateRangeEnd
+                allExams.filter { exam ->
+                    try {
+                        val date = exam.dateTime.substring(0, 10)
+                        date >= start && date < end
+                    } catch (_: Exception) { false }
+                }
+            }
+            
             if (exams.isNotEmpty()) {
                 val monthGroups = exams.groupBy { exam ->
                     try { exam.dateTime.substring(0, 7) } catch (_: Exception) { "未知" }
@@ -102,14 +116,17 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 val busiestMonth = busiestMonthEntry?.let { it.key to it.value }
                 val monthStats = monthGroups.map { (m, l) -> m to l.size }.sortedByDescending { it.second }
                 examAnalysis = ExamAnalysisResult(busiestMonth, monthStats, maxCons, maxStart, maxEnd)
+            } else {
+                examAnalysis = null
             }
         } catch (_: Exception) {}
     }
 
     DividerTextExpandedWith("学业分析", false) {
         CommonNetworkScreen(uiState, onReload = null) {
-            val gradeMap = (uiState as UiState.Success).data
-            val termInfo = parseSemesterInt(semester)
+            Column {
+                val gradeMap = (uiState as UiState.Success).data
+                val termInfo = parseSemesterInt(semester)
 
             val grades = remember(gradeMap, semester) {
                 if (termInfo == null || semester == 0) {
@@ -164,12 +181,13 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                         headlineContent = { Text("共 ${busiestCourses.size} 节课", style = MaterialTheme.typography.headlineMedium) },
                         supportingContent = { Text("平均每周 ${formatDecimal(avgPerWeek, 1)} 节") }
                     )
-                    courseNames.take(6).forEach { name ->
-                        TransplantListItem(headlineContent = { Text(name, style = MaterialTheme.typography.bodyMedium) })
+                    val courseListStr = buildString {
+                        append(courseNames.take(6).joinToString("\n"))
+                        if (courseNames.size > 6) {
+                            append("\n...还有 ${courseNames.size - 6} 门课")
+                        }
                     }
-                    if (courseNames.size > 6) {
-                        TransplantListItem(headlineContent = { Text("...还有 ${courseNames.size - 6} 门课", style = MaterialTheme.typography.bodySmall) })
-                    }
+                    TransplantListItem(headlineContent = { Text(courseListStr, style = MaterialTheme.typography.bodyMedium) })
                 }
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
@@ -195,23 +213,18 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                             trailingContent = { Text("${count}门") }
                         )
                     }
-                }
-
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
-                if (result.maxConsecutiveDays >= 2 && result.consecutiveStart != null && result.consecutiveEnd != null) {
-                    CustomCard(color = cardNormalColor()) {
+                    if (result.maxConsecutiveDays >= 2 && result.consecutiveStart != null && result.consecutiveEnd != null) {
                         TransplantListItem(
                             overlineContent = { Text("连续考试") },
-                            headlineContent = { Text("最长连续考试 ${result.maxConsecutiveDays} 天", style = MaterialTheme.typography.titleMedium) },
+                            headlineContent = { Text("最长连续 ${result.maxConsecutiveDays} 天", style = MaterialTheme.typography.titleMedium) },
                             supportingContent = {
                                 Text("${result.consecutiveStart.format(DateTimeFormatter.ofPattern("M月d日"))} ~ ${result.consecutiveEnd.format(DateTimeFormatter.ofPattern("M月d日"))}")
                             }
                         )
                     }
-
-                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
                 }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
             }
 
             // 学分分布
@@ -291,11 +304,9 @@ fun AcademicAnalysisSection(vm: NetWorkViewModel, semester: Int) {
             CustomCard(color = cardNormalColor()) {
                 TransplantListItem(
                     overlineContent = { Text("学期总结") },
-                    headlineContent = {}
+                    headlineContent = { Text(messages.joinToString("\n"), style = MaterialTheme.typography.bodyMedium) }
                 )
-                messages.forEach { msg ->
-                    TransplantListItem(headlineContent = { Text(msg, style = MaterialTheme.typography.bodyMedium) })
-                }
+            }
             }
         }
     }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicReportSection.kt
@@ -1,11 +1,9 @@
 package com.hfut.schedule.ui.screen.report
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,7 +11,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.hfut.schedule.logic.model.community.GradeJxglstuDTO
@@ -28,18 +25,17 @@ import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.network.CommonNetworkScreen
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
-import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getGpa
-import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getScore
 import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalCredits
 import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalGpa
 import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalScore
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
 import com.xah.common.ui.component.chart.BarChart
-import com.xah.common.ui.component.chart.PieChart
-import com.xah.common.ui.component.chart.PieChartData
-import com.xah.common.ui.style.APP_HORIZONTAL_DP
 import com.xah.common.logic.safeDiv
 import kotlinx.coroutines.flow.first
+import androidx.compose.foundation.layout.padding
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
+
+private data class TermGrades(val term: String, val grades: List<GradeJxglstuResponse>, val passFlags: List<Boolean>)
 
 @Composable
 fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester: (Int) -> Unit) {
@@ -60,12 +56,18 @@ fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester:
 
     DividerTextExpandedWith("学业报表", false) {
         CommonNetworkScreen(uiState, onReload = refreshNetwork) {
-            val gradeMap = (uiState as UiState.Success).data
+            Column {
+                val gradeMap = (uiState as UiState.Success).data
             val allTermList = remember(gradeMap) {
-                gradeMap.toList().sortedByDescending { it.first }.map { (term, items) ->
-                    GradeJxglstuDTO(term, items.filter { !(it.passed && it.gp == 0.0) && it.finalGrade != null }
-                        .map { GradeJxglstuResponse(it.courseNameZh, it.credits.toString(), it.gp.toString(), it.gradeDetail, it.finalGrade!!, it.lessonCode) })
-                }.filter { it.list.isNotEmpty() }
+                gradeMap.toList().sortedByDescending { it.first }.mapNotNull { (term, items) ->
+                    val filtered = items.filter { it.finalGrade != null }
+                    if (filtered.isEmpty()) return@mapNotNull null
+                    TermGrades(
+                        term = term,
+                        grades = filtered.map { GradeJxglstuResponse(it.courseNameZh, it.credits.toString(), it.gp.toString(), it.gradeDetail, it.finalGrade!!, it.lessonCode) },
+                        passFlags = filtered.map { it.passed }
+                    )
+                }
             }
 
             LaunchedEffect(allTermList) {
@@ -80,11 +82,17 @@ fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester:
                 else allTermList.filter { termStringToSemesterInt(it.term) == semester }
             }
 
-            val tc = remember(list) { list.fold(0f) { a, b -> a + getTotalCredits(b) } }
-            val ag = remember(list, tc) { list.fold(0f) { a, b -> a + getTotalGpa(b) } safeDiv tc }
-            val as2 = remember(list, tc) { list.fold(0f) { a, b -> a + getTotalScore(b) } safeDiv tc }
-            val total = remember(list) { list.sumOf { it.list.size } }
-            val passed = remember(list) { list.sumOf { d -> d.list.count { getScore(it.score)?.let { s -> s >= 60f } ?: false } } }
+            val tc = remember(list) { list.fold(0f) { a, b -> a + b.grades.let { g -> g.indices.sumOf { g[it].credits.toFloatOrNull()?.toDouble() ?: 0.0 } }.toFloat() } }
+            val ag = remember(list, tc) {
+                val totalGp = list.sumOf { b -> b.grades.indices.sumOf { i -> (b.grades[i].gpa.toFloatOrNull()?.toDouble() ?: 0.0) * (b.grades[i].credits.toFloatOrNull() ?: 0f) } }.toFloat()
+                totalGp safeDiv tc
+            }
+            val as2 = remember(list, tc) {
+                val totalScore = list.sumOf { b -> b.grades.indices.sumOf { i -> (b.grades[i].detail.toFloatOrNull()?.toDouble() ?: 0.0) * (b.grades[i].credits.toFloatOrNull() ?: 0f) } }.toFloat()
+                totalScore safeDiv tc
+            }
+            val total = remember(list) { list.sumOf { it.grades.size } }
+            val passed = remember(list) { list.sumOf { it.passFlags.count { p -> p } } }
 
             CustomCard(color = cardNormalColor()) {
                 TransplantListItem(
@@ -99,31 +107,31 @@ fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester:
             Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
             if (allTermList.size > 1) {
-                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP, vertical = CARD_NORMAL_DP), contentAlignment = Alignment.Center) {
-                    BarChart(data = allTermList.reversed().associate { it.term to getTotalGpa(it) }, showLabel = false, title = "各学期GPA")
+                val gpaData = remember(allTermList) {
+                    allTermList.reversed().associate { tg ->
+                        val credits = tg.grades.sumOf { it.credits.toFloatOrNull()?.toDouble() ?: 0.0 }.toFloat()
+                        val gp = tg.grades.indices.sumOf { i -> (tg.grades[i].gpa.toFloatOrNull()?.toDouble() ?: 0.0) * (tg.grades[i].credits.toFloatOrNull() ?: 0f) }.toFloat()
+                        tg.term to (gp safeDiv credits)
+                    }
+                }
+                CustomCard(color = cardNormalColor()) {
+                    BarChart(data = gpaData, showLabel = false, title = "各学期GPA", modifier = Modifier.padding(APP_HORIZONTAL_DP))
                 }
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
             }
 
-            if (total > 0) {
-                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP, vertical = CARD_NORMAL_DP), contentAlignment = Alignment.Center) {
-                    PieChart(data = listOf(PieChartData("通过", passed.toFloat()), PieChartData("未通过", (total - passed).toFloat())), title = "课程通过率")
-                }
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-            }
-
-            list.reversed().forEach { dto ->
-                val ctc = remember { getTotalCredits(dto) }
-                val ctg = remember { getTotalGpa(dto) }
-                val cts = remember { getTotalScore(dto) }
+            list.reversed().forEach { tg ->
+                val ctc = tg.grades.let { g -> g.indices.sumOf { g[it].credits.toFloatOrNull()?.toDouble() ?: 0.0 } }.toFloat()
+                val ctg = tg.grades.indices.sumOf { i -> (tg.grades[i].gpa.toFloatOrNull()?.toDouble() ?: 0.0) * (tg.grades[i].credits.toFloatOrNull() ?: 0f) }.toFloat()
+                val cts = tg.grades.indices.sumOf { i -> (tg.grades[i].detail.toFloatOrNull()?.toDouble() ?: 0.0) * (tg.grades[i].credits.toFloatOrNull() ?: 0f) }.toFloat()
                 val cag = ctg safeDiv ctc
                 val cas = cts safeDiv ctc
-                val cc = dto.list.size
-                val pc = dto.list.count { getScore(it.score)?.let { s -> s >= 60f } ?: false }
+                val cc = tg.grades.size
+                val pc = tg.passFlags.count { it }
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        overlineContent = { Text(dto.term) },
+                        overlineContent = { Text(tg.term) },
                         headlineContent = { Text("分数 ${formatDecimal(cas.toDouble(), 2)} | 绩点 ${formatDecimal(cag.toDouble(), 2)}", style = MaterialTheme.typography.titleSmall) },
                         trailingContent = { Text("${cc}科") }
                     )
@@ -131,6 +139,7 @@ fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester:
                         TransplantListItem(overlineContent = { Text("学分") }, headlineContent = { Text(formatDecimal(ctc.toDouble(), 1)) }, modifier = Modifier.weight(1f))
                         TransplantListItem(overlineContent = { Text("通过") }, headlineContent = { Text("$pc/$cc") }, modifier = Modifier.weight(1f))
                     }
+                }
                 }
             }
         }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/AcademicReportSection.kt
@@ -1,0 +1,138 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.logic.model.community.GradeJxglstuDTO
+import com.hfut.schedule.logic.model.community.GradeJxglstuResponse
+import com.hfut.schedule.logic.network.repo.UniAppRepository
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.parse.formatDecimal
+import com.hfut.schedule.logic.util.storage.kv.DataStoreManager
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.network.CommonNetworkScreen
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getGpa
+import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getScore
+import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalCredits
+import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalGpa
+import com.hfut.schedule.ui.screen.grade.grade.jxglstu.getTotalScore
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.xah.common.ui.component.chart.BarChart
+import com.xah.common.ui.component.chart.PieChart
+import com.xah.common.ui.component.chart.PieChartData
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
+import com.xah.common.logic.safeDiv
+import kotlinx.coroutines.flow.first
+
+@Composable
+fun AcademicReportSection(vm: NetWorkViewModel, semester: Int, onLatestSemester: (Int) -> Unit) {
+    val uiState by vm.uniAppGradesResp.state.collectAsState()
+
+    val refreshNetwork: suspend () -> Unit = m@ {
+        if (uiState is UiState.Success) return@m
+        var cookie = DataStoreManager.uniAppJwt.first()
+        if (cookie.isEmpty()) {
+            if (UniAppRepository.login() == false) return@m
+            cookie = DataStoreManager.uniAppJwt.first()
+        }
+        vm.uniAppGradesResp.clear()
+        vm.getUniAppGrades(cookie)
+    }
+
+    LaunchedEffect(Unit) { refreshNetwork() }
+
+    DividerTextExpandedWith("学业报表", false) {
+        CommonNetworkScreen(uiState, onReload = refreshNetwork) {
+            val gradeMap = (uiState as UiState.Success).data
+            val allTermList = remember(gradeMap) {
+                gradeMap.toList().sortedByDescending { it.first }.map { (term, items) ->
+                    GradeJxglstuDTO(term, items.filter { !(it.passed && it.gp == 0.0) && it.finalGrade != null }
+                        .map { GradeJxglstuResponse(it.courseNameZh, it.credits.toString(), it.gp.toString(), it.gradeDetail, it.finalGrade!!, it.lessonCode) })
+                }.filter { it.list.isNotEmpty() }
+            }
+
+            LaunchedEffect(allTermList) {
+                if (allTermList.isNotEmpty()) {
+                    latestSemesterFromTerms(allTermList.map { it.term })?.let { onLatestSemester(it) }
+                }
+            }
+
+            val termInfo = remember(semester) { parseSemesterInt(semester) }
+            val list = remember(allTermList, termInfo) {
+                if (termInfo == null || semester == 0) allTermList
+                else allTermList.filter { termStringToSemesterInt(it.term) == semester }
+            }
+
+            val tc = remember(list) { list.fold(0f) { a, b -> a + getTotalCredits(b) } }
+            val ag = remember(list, tc) { list.fold(0f) { a, b -> a + getTotalGpa(b) } safeDiv tc }
+            val as2 = remember(list, tc) { list.fold(0f) { a, b -> a + getTotalScore(b) } safeDiv tc }
+            val total = remember(list) { list.sumOf { it.list.size } }
+            val passed = remember(list) { list.sumOf { d -> d.list.count { getScore(it.score)?.let { s -> s >= 60f } ?: false } } }
+
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
+                    headlineContent = { Text("总科目 $total | 通过 $passed | 未通过 ${total - passed}", style = MaterialTheme.typography.titleMedium) }
+                )
+                TransplantListItem(overlineContent = { Text("加权平均分") }, headlineContent = { Text(formatDecimal(as2.toDouble(), 2), style = MaterialTheme.typography.headlineMedium) })
+                TransplantListItem(overlineContent = { Text("加权GPA") }, headlineContent = { Text(formatDecimal(ag.toDouble(), 2), style = MaterialTheme.typography.headlineMedium) })
+                TransplantListItem(overlineContent = { Text("总学分") }, headlineContent = { Text(formatDecimal(tc.toDouble(), 1), style = MaterialTheme.typography.headlineMedium) })
+            }
+
+            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+            if (allTermList.size > 1) {
+                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP, vertical = CARD_NORMAL_DP), contentAlignment = Alignment.Center) {
+                    BarChart(data = allTermList.reversed().associate { it.term to getTotalGpa(it) }, showLabel = false, title = "各学期GPA")
+                }
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+            }
+
+            if (total > 0) {
+                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP, vertical = CARD_NORMAL_DP), contentAlignment = Alignment.Center) {
+                    PieChart(data = listOf(PieChartData("通过", passed.toFloat()), PieChartData("未通过", (total - passed).toFloat())), title = "课程通过率")
+                }
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+            }
+
+            list.reversed().forEach { dto ->
+                val ctc = remember { getTotalCredits(dto) }
+                val ctg = remember { getTotalGpa(dto) }
+                val cts = remember { getTotalScore(dto) }
+                val cag = ctg safeDiv ctc
+                val cas = cts safeDiv ctc
+                val cc = dto.list.size
+                val pc = dto.list.count { getScore(it.score)?.let { s -> s >= 60f } ?: false }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text(dto.term) },
+                        headlineContent = { Text("分数 ${formatDecimal(cas.toDouble(), 2)} | 绩点 ${formatDecimal(cag.toDouble(), 2)}", style = MaterialTheme.typography.titleSmall) },
+                        trailingContent = { Text("${cc}科") }
+                    )
+                    Row {
+                        TransplantListItem(overlineContent = { Text("学分") }, headlineContent = { Text(formatDecimal(ctc.toDouble(), 1)) }, modifier = Modifier.weight(1f))
+                        TransplantListItem(overlineContent = { Text("通过") }, headlineContent = { Text("$pc/$cc") }, modifier = Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -27,6 +27,7 @@ import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
 import com.xah.common.ui.component.chart.BarChart
+import com.xah.common.ui.component.chart.LineChart
 import com.xah.common.ui.component.chart.PieChart
 import com.xah.common.ui.component.chart.PieChartData
 import com.xah.common.ui.style.APP_HORIZONTAL_DP
@@ -55,13 +56,18 @@ private fun classifyMeal(resume: String, time: String): String {
 @Composable
 fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
     val billState by vm.huiXinBillResult.state.collectAsState()
+    val predictedState by vm.cardPredictedResponse.state.collectAsState()
 
     LaunchedEffect(Unit) {
-        if (billState !is UiState.Success) {
-            val auth = prefs.getString("auth", "") ?: ""
-            if (auth.isNotEmpty()) {
+        val auth = prefs.getString("auth", "") ?: ""
+        if (auth.isNotEmpty()) {
+            if (billState !is UiState.Success) {
                 vm.huiXinBillResult.clear()
                 vm.getCardBill("bearer $auth", 1, 500)
+            }
+            if (predictedState !is UiState.Success) {
+                vm.cardPredictedResponse.clear()
+                vm.getCardPredicted("bearer $auth")
             }
         }
     }
@@ -77,7 +83,7 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                     else {
                         val start = termInfo.dateRangeStart
                         val end = termInfo.dateRangeEnd
-                        allRecords.filter { it.effectdateStr.substring(0, 7) >= start && it.effectdateStr.substring(0, 7) < end }
+                        allRecords.filter { it.effectdateStr.substring(0, 7) in start..<end }
                     }
                 }
 
@@ -91,6 +97,13 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 // 基础统计
                 val totalAmount = remember(records) { records.sumOf { (it.tranamt ?: 0) / 100.0 } }
                 val avgPerTransaction = remember(records) { if (records.isEmpty()) 0.0 else totalAmount / records.size }
+                
+                val activeDays = remember(records) { records.map { it.effectdateStr.substringBefore(" ") }.distinct().size }
+                val dailyAvg = remember(totalAmount, activeDays) { if (activeDays > 0) totalAmount / activeDays else 0.0 }
+                
+                val activeMonths = remember(records) { records.map { it.effectdateStr.substringBeforeLast("-") }.distinct().size }
+                val monthlyAvg = remember(totalAmount, activeMonths) { if (activeMonths > 0) totalAmount / activeMonths else 0.0 }
+
                 val sorted = remember(records) { records.sortedBy { it.jndatetimeStr } }
                 val earliest = sorted.first()
                 val latest = sorted.last()
@@ -200,7 +213,7 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
-                // 消费概览 + 消费足迹
+                // 消费概览
                 val earliestLatestByTime = remember(records) {
                     try {
                         records.mapNotNull { record ->
@@ -217,14 +230,27 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        overlineContent = { Text("消费概览") },
+                        overlineContent = { Text("总消费") },
                         headlineContent = { Text("￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.headlineMedium) },
                         supportingContent = { Text("共 ${records.size} 笔 | 跨越 $days 天") }
                     )
-                    TransplantListItem(
-                        overlineContent = { Text("平均单笔") },
-                        headlineContent = { Text("￥${formatDecimal(avgPerTransaction, 2)}", style = MaterialTheme.typography.titleMedium) }
-                    )
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        TransplantListItem(
+                            overlineContent = { Text("日均") },
+                            headlineContent = { Text("￥${formatDecimal(dailyAvg, 2)}", style = MaterialTheme.typography.titleMedium) },
+                            modifier = Modifier.weight(1f)
+                        )
+                        TransplantListItem(
+                            overlineContent = { Text("月均") },
+                            headlineContent = { Text("￥${formatDecimal(monthlyAvg, 2)}", style = MaterialTheme.typography.titleMedium) },
+                            modifier = Modifier.weight(1f)
+                        )
+                        TransplantListItem(
+                            overlineContent = { Text("单笔均") },
+                            headlineContent = { Text("￥${formatDecimal(avgPerTransaction, 2)}", style = MaterialTheme.typography.titleMedium) },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                     if (highestRecord != null) {
                         TransplantListItem(
                             overlineContent = { Text("单笔最高") },
@@ -232,21 +258,123 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                             supportingContent = { Text("${highestRecord.resume.substringBefore("-").take(15)} | ${highestRecord.jndatetimeStr}") }
                         )
                     }
-                    earliestLatestByTime.first?.let { (_, date, time) ->
-                        TransplantListItem(
-                            overlineContent = { Text("最早消费") },
-                            headlineContent = { Text("${date} $time", style = MaterialTheme.typography.bodyMedium) }
-                        )
-                    }
-                    earliestLatestByTime.second?.let { (_, date, time) ->
-                        TransplantListItem(
-                            overlineContent = { Text("最晚消费") },
-                            headlineContent = { Text("${date} $time", style = MaterialTheme.typography.bodyMedium) }
-                        )
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        earliestLatestByTime.first?.let { (_, date, time) ->
+                            TransplantListItem(
+                                overlineContent = { Text("最早消费") },
+                                headlineContent = { Text("$date $time", style = MaterialTheme.typography.bodySmall) },
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                        earliestLatestByTime.second?.let { (_, date, time) ->
+                            TransplantListItem(
+                                overlineContent = { Text("最晚消费") },
+                                headlineContent = { Text("$date $time", style = MaterialTheme.typography.bodySmall) },
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
                     }
                 }
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                if (predictedState is UiState.Success) {
+                    val predictData = (predictedState as UiState.Success).data
+                    CustomCard(color = cardNormalColor()) {
+                        androidx.compose.foundation.layout.Row(modifier = Modifier.fillMaxWidth()) {
+                            TransplantListItem(
+                                overlineContent = { Text("明日预计") },
+                                headlineContent = { Text("￥${formatDecimal(predictData.day.predictData.predict, 2)}", style = MaterialTheme.typography.titleMedium) },
+                                modifier = Modifier.weight(1f)
+                            )
+                            TransplantListItem(
+                                overlineContent = { Text("下月预计") },
+                                headlineContent = { Text("￥${formatDecimal(predictData.month.predictData.predict, 2)}", style = MaterialTheme.typography.titleMedium) },
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+
+                // 每学期各周最早/最晚消费时间折线图
+                val semesterWeekTimeStats = remember(records) {
+                    try {
+                        val sortedByDate = records.mapNotNull {
+                            val timeStr = it.jndatetimeStr.substringAfter(" ")
+                            val dateStr = it.effectdateStr.substringBefore(" ")
+                            if (timeStr.isNotEmpty() && dateStr.isNotEmpty()) {
+                                val date = LocalDate.parse(dateStr)
+                                val hour = timeStr.substringBefore(":").toDoubleOrNull() ?: return@mapNotNull null
+                                val minute = timeStr.substringAfter(":").substringBefore(":").toDoubleOrNull() ?: 0.0
+                                val timeDecimal = hour + minute / 60.0
+                                Triple(it, date, timeDecimal)
+                            } else null
+                        }.sortedBy { it.second }
+
+                        if (sortedByDate.isEmpty()) Pair(emptyMap(), emptyMap())
+                        else {
+                            val firstDate = sortedByDate.first().second
+                            val earliestMap = mutableMapOf<Int, Double>()
+                            val latestMap = mutableMapOf<Int, Double>()
+                            
+                            for (item in sortedByDate) {
+                                val weekNum = (ChronoUnit.DAYS.between(firstDate, item.second) / 7 + 1).toInt()
+                                val timeDecimal = item.third
+                                
+                                val curEarliest = earliestMap[weekNum]
+                                if (curEarliest == null || timeDecimal < curEarliest) {
+                                    earliestMap[weekNum] = timeDecimal
+                                }
+                                val curLatest = latestMap[weekNum]
+                                if (curLatest == null || timeDecimal > curLatest) {
+                                    latestMap[weekNum] = timeDecimal
+                                }
+                            }
+                            
+                            val earliestChart = earliestMap.entries.sortedBy { it.key }.associate { it.key.toString() to it.value.toFloat() }
+                            val latestChart = latestMap.entries.sortedBy { it.key }.associate { it.key.toString() to it.value.toFloat() }
+                            
+                            Pair(earliestChart, latestChart)
+                        }
+                    } catch (_: Exception) { Pair(emptyMap(), emptyMap()) }
+                }
+
+                val (earliestTimeData, latestTimeData) = semesterWeekTimeStats
+                if (earliestTimeData.isNotEmpty()) {
+                    val timeFormatter: (Float) -> String = {
+                        val h = it.toInt()
+                        val m = ((it - h) * 60).toInt()
+                        "${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}"
+                    }
+
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("各周消费时间分布 (横轴:周)") },
+                            headlineContent = { Text("最早消费时间", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        LineChart(
+                            data = earliestTimeData,
+                            showLabel = true,
+                            modifier = Modifier.padding(horizontal = APP_HORIZONTAL_DP).height(120.dp),
+                            xLabelSpacing = 4,
+                            yAxisFormatter = timeFormatter
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        TransplantListItem(
+                            headlineContent = { Text("最晚消费时间", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        LineChart(
+                            data = latestTimeData,
+                            showLabel = true,
+                            modifier = Modifier.padding(horizontal = APP_HORIZONTAL_DP).height(120.dp),
+                            xLabelSpacing = 4,
+                            yAxisFormatter = timeFormatter
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
 
                 // 周几消费最多
                 val weekdayChartData = remember(weekdayStats) {
@@ -324,7 +452,7 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                         if (totalAmount > 5000) add("本学期消费超过 5000 元，省着点花哦~")
                         if (totalAmount < 1000) add("本学期消费不到 1000 元，省钱冠军就是你！")
 
-                        if (days > 100) add("跨越 ${days} 天的消费记录，你一直在坚持记账！")
+                        if (days > 100) add("跨越 $days 天的消费记录，你一直在坚持记账！")
 
                         if (avgPerDay > 30) add("日均消费 ￥${formatDecimal(avgPerDay, 0)}，食堂不香吗？")
                         else if (avgPerDay < 15) add("日均消费 ￥${formatDecimal(avgPerDay, 0)}，你是省钱小能手！")

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -1,0 +1,281 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.parse.formatDecimal
+import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+private fun classifyMeal(resume: String, time: String): String {
+    val hour = try {
+        time.substringAfter(" ").substringBefore(":").toIntOrNull() ?: -1
+    } catch (_: Exception) { -1 }
+    val name = resume.lowercase()
+    return when {
+        name.contains("充值") || name.contains("补助") || name.contains("转账") -> "其他"
+        hour in 6..10 -> "早餐"
+        hour in 11..13 -> "午餐"
+        hour in 14..16 -> "下午茶"
+        hour in 17..19 -> "晚餐"
+        hour in 20..23 -> "夜宵"
+        else -> "其他"
+    }
+}
+
+@Composable
+fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
+    val billState by vm.huiXinBillResult.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        if (billState !is UiState.Success) {
+            val auth = prefs.getString("auth", "") ?: ""
+            if (auth.isNotEmpty()) {
+                vm.huiXinBillResult.clear()
+                vm.getCardBill("bearer $auth", 1, 500)
+            }
+        }
+    }
+
+    DividerTextExpandedWith("消费分析", false) {
+        when (billState) {
+            is UiState.Success -> {
+                val allRecords = (billState as UiState.Success).data.records.filter { it.turnoverType == "消费" }
+                val termInfo = parseSemesterInt(semester)
+
+                val records = remember(allRecords, semester) {
+                    if (termInfo == null || semester == 0) allRecords
+                    else {
+                        val start = termInfo.dateRangeStart
+                        val end = termInfo.dateRangeEnd
+                        allRecords.filter { it.effectdateStr.substring(0, 7) >= start && it.effectdateStr.substring(0, 7) < end }
+                    }
+                }
+
+                if (records.isEmpty()) {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(headlineContent = { Text("暂无消费记录") })
+                    }
+                    return@DividerTextExpandedWith
+                }
+
+                // 基础统计
+                val totalAmount = remember(records) { records.sumOf { (it.tranamt ?: 0) / 100.0 } }
+                val avgPerTransaction = remember(records) { if (records.isEmpty()) 0.0 else totalAmount / records.size }
+                val sorted = remember(records) { records.sortedBy { it.jndatetimeStr } }
+                val earliest = sorted.first()
+                val latest = sorted.last()
+                val days = remember(sorted) {
+                    try {
+                        val f = LocalDate.parse(earliest.effectdateStr.substringBefore(" "))
+                        val l = LocalDate.parse(latest.effectdateStr.substringBefore(" "))
+                        ChronoUnit.DAYS.between(f, l).toInt()
+                    } catch (_: Exception) { 0 }
+                }
+
+                // 单笔最高消费
+                val highestRecord = remember(records) { records.maxByOrNull { (it.tranamt ?: 0) } }
+                val highestAmount = remember(highestRecord) { ((highestRecord?.tranamt ?: 0) / 100.0) }
+
+                // 周几消费最多
+                val weekdayStats = remember(records) {
+                    val dayMap = mutableMapOf<Int, Double>()
+                    for (record in records) {
+                        try {
+                            val date = LocalDate.parse(record.effectdateStr.substringBefore(" "))
+                            val dayOfWeek = date.dayOfWeek.value // 1=Monday, 7=Sunday
+                            dayMap[dayOfWeek] = (dayMap[dayOfWeek] ?: 0.0) + ((record.tranamt ?: 0) / 100.0)
+                        } catch (_: Exception) {}
+                    }
+                    dayMap.toList().sortedByDescending { it.second }
+                }
+                val busiestWeekday = weekdayStats.firstOrNull()
+
+                // 早午晚餐分类
+                val mealGroups = remember(records) {
+                    records.groupBy { classifyMeal(it.resume, it.jndatetimeStr) }
+                }
+                val mealStats = remember(mealGroups) {
+                    listOf("早餐", "午餐", "下午茶", "晚餐", "夜宵").mapNotNull { meal ->
+                        val items = mealGroups[meal] ?: return@mapNotNull null
+                        val total = items.sumOf { (it.tranamt ?: 0) / 100.0 }
+                        Triple(meal, items.size, total)
+                    }.sortedByDescending { it.third }
+                }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
+                        headlineContent = { Text("餐饮消费分析", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    mealStats.forEach { (meal, count, amount) ->
+                        TransplantListItem(
+                            overlineContent = { Text("$meal ${count}次") },
+                            headlineContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.titleMedium) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 最常消费地点
+                val merchants = remember(records) {
+                    records.groupBy { it.resume.substringBefore("-").replace("有限公司", "").trim() }
+                        .mapValues { (_, v) -> v.size to v.sumOf { (it.tranamt ?: 0) / 100.0 } }
+                        .toList().sortedByDescending { it.second.first }.take(5)
+                }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("最常消费") },
+                        headlineContent = { Text("Top 5 消费地点", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    merchants.forEach { (name, pair) ->
+                        TransplantListItem(
+                            overlineContent = { Text("${pair.first}次") },
+                            headlineContent = { Text(name) },
+                            trailingContent = { Text("￥${formatDecimal(pair.second, 2)}") }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 消费概览
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("消费概览") },
+                        headlineContent = { Text("总览", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("总消费") },
+                        headlineContent = { Text("￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.headlineMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("平均单笔") },
+                        headlineContent = { Text("￥${formatDecimal(avgPerTransaction, 2)}", style = MaterialTheme.typography.headlineMedium) }
+                    )
+                    if (highestRecord != null) {
+                        TransplantListItem(
+                            overlineContent = { Text("单笔最高") },
+                            headlineContent = { Text("￥${formatDecimal(highestAmount, 2)}", style = MaterialTheme.typography.headlineMedium) },
+                            supportingContent = { Text("${highestRecord.resume.substringBefore("-").take(15)} | ${highestRecord.jndatetimeStr}") }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 周几消费最多
+                if (weekdayStats.isNotEmpty()) {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("星期分析") },
+                            headlineContent = { Text("哪天最能花", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        weekdayStats.forEach { (dayOfWeek, amount) ->
+                            val dayName = DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
+                            TransplantListItem(
+                                headlineContent = { Text("周$dayName") },
+                                trailingContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.titleMedium) }
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+
+                // 消费足迹
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("消费足迹") },
+                        headlineContent = { Text("最早记录 ${earliest.jndatetimeStr}", style = MaterialTheme.typography.bodyMedium) }
+                    )
+                    TransplantListItem(
+                        headlineContent = { Text("最晚记录 ${latest.jndatetimeStr}", style = MaterialTheme.typography.bodyMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("跨越 $days 天") },
+                        headlineContent = { Text("共 ${records.size} 笔 | ￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.titleMedium) }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 小贴士
+                val messages = remember(totalAmount, records.size, days, avgPerTransaction, highestAmount, busiestWeekday) {
+                    mutableListOf<String>().apply {
+                        val avgPerDay = if (days > 0) totalAmount / days else 0.0
+
+                        add("本学期共消费 ${records.size} 笔，总计 ￥${formatDecimal(totalAmount, 2)}")
+                        add("平均每笔消费 ￥${formatDecimal(avgPerTransaction, 2)}")
+
+                        if (records.size > 100) add("你真是个消费达人，${records.size} 笔消费记录！")
+                        if (records.size < 10) add("消费记录这么少，你是用现金的吗？")
+
+                        if (totalAmount > 5000) add("本学期消费超过 5000 元，省着点花哦~")
+                        if (totalAmount < 1000) add("本学期消费不到 1000 元，省钱冠军就是你！")
+
+                        if (days > 100) add("跨越 ${days} 天的消费记录，你一直在坚持记账！")
+
+                        if (avgPerDay > 30) add("日均消费 ￥${formatDecimal(avgPerDay, 0)}，食堂不香吗？")
+                        else if (avgPerDay < 15) add("日均消费 ￥${formatDecimal(avgPerDay, 0)}，你是省钱小能手！")
+                        else add("日均消费 ￥${formatDecimal(avgPerDay, 0)}，花得刚刚好~")
+
+                        if (highestAmount > 200) add("单笔最高 ￥${formatDecimal(highestAmount, 0)}，这是吃了什么大餐？")
+                        if (highestAmount in 50.0..100.0) add("单笔最高 ￥${formatDecimal(highestAmount, 0)}，是不是买了什么好东西？")
+
+                        busiestWeekday?.let { (day, _) ->
+                            val dayName = DayOfWeek.of(day).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
+                            add("你最能花的一天是周$dayName，小心钱包~")
+                        }
+
+                        if (avgPerTransaction > 30) add("平均单笔 ￥${formatDecimal(avgPerTransaction, 0)}，偶尔奢侈一下也不错~")
+                        if (avgPerTransaction < 10) add("平均单笔不到 ￥10，勤俭持家！")
+
+                        if (isEmpty()) add("本学期共消费 ${records.size} 笔，总计 ￥${formatDecimal(totalAmount, 2)}")
+                    }
+                }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("小贴士") },
+                        headlineContent = {}
+                    )
+                    messages.forEach { msg ->
+                        TransplantListItem(headlineContent = { Text(msg, style = MaterialTheme.typography.bodyMedium) })
+                    }
+                }
+            }
+            is UiState.Error -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("暂无消费数据") }, supportingContent = { Text("请先在一卡通页面加载数据") })
+                }
+            }
+            else -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("加载中...") })
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -3,6 +3,11 @@ package com.hfut.schedule.ui.screen.report
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Alignment
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -132,16 +137,27 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                         overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
                         headlineContent = { Text("餐饮消费分析", style = MaterialTheme.typography.titleMedium) }
                     )
-                    PieChart(
-                        data = mealStats.map { (meal, _, amount) -> PieChartData(meal, amount.toFloat()) },
-                        modifier = Modifier.padding(APP_HORIZONTAL_DP),
-                        title = "餐饮消费比例"
-                    )
-                    mealStats.forEach { (meal, count, amount) ->
-                        TransplantListItem(
-                            overlineContent = { Text("$meal ${count}次") },
-                            headlineContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.titleMedium) }
-                        )
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            mealStats.forEach { (meal, count, amount) ->
+                                TransplantListItem(
+                                    overlineContent = { Text("$meal ${count}次", style = MaterialTheme.typography.bodySmall) },
+                                    headlineContent = { Text("￥${formatDecimal(amount, 0)}", style = MaterialTheme.typography.titleSmall) },
+                                    usePadding = false,
+                                    modifier = Modifier.padding(vertical = 2.dp)
+                                )
+                            }
+                        }
+                        Box(modifier = Modifier.weight(2f)) {
+                            PieChart(
+                                data = mealStats.map { (meal, _, amount) -> PieChartData(meal, amount.toFloat()) },
+                                modifier = Modifier.fillMaxWidth().height(200.dp),
+                                title = "比例"
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -170,57 +170,7 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
-                // 消费概览
-                CustomCard(color = cardNormalColor()) {
-                    TransplantListItem(
-                        overlineContent = { Text("消费概览") },
-                        headlineContent = { Text("总览", style = MaterialTheme.typography.titleMedium) }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("总消费") },
-                        headlineContent = { Text("￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.headlineMedium) }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("平均单笔") },
-                        headlineContent = { Text("￥${formatDecimal(avgPerTransaction, 2)}", style = MaterialTheme.typography.headlineMedium) }
-                    )
-                    if (highestRecord != null) {
-                        TransplantListItem(
-                            overlineContent = { Text("单笔最高") },
-                            headlineContent = { Text("￥${formatDecimal(highestAmount, 2)}", style = MaterialTheme.typography.headlineMedium) },
-                            supportingContent = { Text("${highestRecord.resume.substringBefore("-").take(15)} | ${highestRecord.jndatetimeStr}") }
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
-                // 周几消费最多
-                val weekdayChartData = remember(weekdayStats) {
-                    (1..7).associate { dayOfWeek ->
-                        val dayName = "周${DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)}"
-                        val amount = weekdayStats.find { it.first == dayOfWeek }?.second ?: 0.0
-                        dayName to amount.toFloat()
-                    }
-                }
-
-                if (weekdayStats.isNotEmpty()) {
-                    CustomCard(color = cardNormalColor()) {
-                        TransplantListItem(
-                            overlineContent = { Text("星期分析") },
-                            headlineContent = { Text("哪天最能花", style = MaterialTheme.typography.titleMedium) }
-                        )
-                        BarChart(
-                            data = weekdayChartData,
-                            showLabel = true,
-                            modifier = Modifier.padding(APP_HORIZONTAL_DP)
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-                }
-
-                // 消费足迹：按每天最早/最晚消费时间
+                // 消费概览 + 消费足迹
                 val earliestLatestByTime = remember(records) {
                     try {
                         records.mapNotNull { record ->
@@ -237,10 +187,21 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
-                        overlineContent = { Text("消费足迹") },
-                        headlineContent = { Text("跨越 $days 天", style = MaterialTheme.typography.titleMedium) },
-                        supportingContent = { Text("共 ${records.size} 笔 | ￥${formatDecimal(totalAmount, 2)}") }
+                        overlineContent = { Text("消费概览") },
+                        headlineContent = { Text("￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.headlineMedium) },
+                        supportingContent = { Text("共 ${records.size} 笔 | 跨越 $days 天") }
                     )
+                    TransplantListItem(
+                        overlineContent = { Text("平均单笔") },
+                        headlineContent = { Text("￥${formatDecimal(avgPerTransaction, 2)}", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    if (highestRecord != null) {
+                        TransplantListItem(
+                            overlineContent = { Text("单笔最高") },
+                            headlineContent = { Text("￥${formatDecimal(highestAmount, 2)}", style = MaterialTheme.typography.titleMedium) },
+                            supportingContent = { Text("${highestRecord.resume.substringBefore("-").take(15)} | ${highestRecord.jndatetimeStr}") }
+                        )
+                    }
                     earliestLatestByTime.first?.let { (_, date, time) ->
                         TransplantListItem(
                             overlineContent = { Text("最早消费") },
@@ -253,6 +214,39 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                             headlineContent = { Text("${date} $time", style = MaterialTheme.typography.bodyMedium) }
                         )
                     }
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                // 周几消费最多
+                val weekdayChartData = remember(weekdayStats) {
+                    (1..7).associate { dayOfWeek ->
+                        val dayName = DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
+                        val amount = weekdayStats.find { it.first == dayOfWeek }?.second ?: 0.0
+                        dayName to amount.toFloat()
+                    }
+                }
+
+                if (weekdayStats.isNotEmpty()) {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("星期分析") },
+                            headlineContent = { Text("哪天最能花", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        BarChart(
+                            data = weekdayChartData,
+                            modifier = Modifier.padding(horizontal = APP_HORIZONTAL_DP, vertical = 8.dp)
+                        )
+                        weekdayStats.forEach { (dayOfWeek, amount) ->
+                            val dayName = DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
+                            TransplantListItem(
+                                headlineContent = { Text(dayName, style = MaterialTheme.typography.bodyMedium) },
+                                trailingContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.bodyMedium) }
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
                 }
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
@@ -295,11 +289,8 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
                         overlineContent = { Text("小贴士") },
-                        headlineContent = {}
+                        headlineContent = { Text(messages.joinToString("\n"), style = MaterialTheme.typography.bodyMedium) }
                     )
-                    messages.forEach { msg ->
-                        TransplantListItem(headlineContent = { Text(msg, style = MaterialTheme.typography.bodyMedium) })
-                    }
                 }
             }
             is UiState.Error -> {

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -2,6 +2,7 @@ package com.hfut.schedule.ui.screen.report
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,6 +21,10 @@ import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.xah.common.ui.component.chart.BarChart
+import com.xah.common.ui.component.chart.PieChart
+import com.xah.common.ui.component.chart.PieChartData
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.format.TextStyle
@@ -127,6 +132,11 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                         overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
                         headlineContent = { Text("餐饮消费分析", style = MaterialTheme.typography.titleMedium) }
                     )
+                    PieChart(
+                        data = mealStats.map { (meal, _, amount) -> PieChartData(meal, amount.toFloat()) },
+                        modifier = Modifier.padding(APP_HORIZONTAL_DP),
+                        title = "餐饮消费比例"
+                    )
                     mealStats.forEach { (meal, count, amount) ->
                         TransplantListItem(
                             overlineContent = { Text("$meal ${count}次") },
@@ -186,37 +196,63 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
                 // 周几消费最多
+                val weekdayChartData = remember(weekdayStats) {
+                    (1..7).associate { dayOfWeek ->
+                        val dayName = "周${DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)}"
+                        val amount = weekdayStats.find { it.first == dayOfWeek }?.second ?: 0.0
+                        dayName to amount.toFloat()
+                    }
+                }
+
                 if (weekdayStats.isNotEmpty()) {
                     CustomCard(color = cardNormalColor()) {
                         TransplantListItem(
                             overlineContent = { Text("星期分析") },
                             headlineContent = { Text("哪天最能花", style = MaterialTheme.typography.titleMedium) }
                         )
-                        weekdayStats.forEach { (dayOfWeek, amount) ->
-                            val dayName = DayOfWeek.of(dayOfWeek).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
-                            TransplantListItem(
-                                headlineContent = { Text("周$dayName") },
-                                trailingContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.titleMedium) }
-                            )
-                        }
+                        BarChart(
+                            data = weekdayChartData,
+                            showLabel = true,
+                            modifier = Modifier.padding(APP_HORIZONTAL_DP)
+                        )
                     }
 
                     Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
                 }
 
-                // 消费足迹
+                // 消费足迹：按每天最早/最晚消费时间
+                val earliestLatestByTime = remember(records) {
+                    try {
+                        records.mapNotNull { record ->
+                            val time = record.jndatetimeStr.substringAfter(" ").substringBeforeLast(":")
+                            val date = record.effectdateStr.substringBefore(" ")
+                            if (time.isNotEmpty() && date.isNotEmpty()) Triple(record, date, time) else null
+                        }.let { triples ->
+                            val earliest = triples.minByOrNull { it.third }
+                            val latest = triples.maxByOrNull { it.third }
+                            Pair(earliest, latest)
+                        }
+                    } catch (_: Exception) { null to null }
+                }
+
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(
                         overlineContent = { Text("消费足迹") },
-                        headlineContent = { Text("最早记录 ${earliest.jndatetimeStr}", style = MaterialTheme.typography.bodyMedium) }
+                        headlineContent = { Text("跨越 $days 天", style = MaterialTheme.typography.titleMedium) },
+                        supportingContent = { Text("共 ${records.size} 笔 | ￥${formatDecimal(totalAmount, 2)}") }
                     )
-                    TransplantListItem(
-                        headlineContent = { Text("最晚记录 ${latest.jndatetimeStr}", style = MaterialTheme.typography.bodyMedium) }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("跨越 $days 天") },
-                        headlineContent = { Text("共 ${records.size} 笔 | ￥${formatDecimal(totalAmount, 2)}", style = MaterialTheme.typography.titleMedium) }
-                    )
+                    earliestLatestByTime.first?.let { (_, date, time) ->
+                        TransplantListItem(
+                            overlineContent = { Text("最早消费") },
+                            headlineContent = { Text("${date} $time", style = MaterialTheme.typography.bodyMedium) }
+                        )
+                    }
+                    earliestLatestByTime.second?.let { (_, date, time) ->
+                        TransplantListItem(
+                            overlineContent = { Text("最晚消费") },
+                            headlineContent = { Text("${date} $time", style = MaterialTheme.typography.bodyMedium) }
+                        )
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseAnalysisSection.kt
@@ -120,6 +120,20 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                 }
                 val busiestWeekday = weekdayStats.firstOrNull()
 
+                // 哪个月消费最多
+                val monthStats = remember(records) {
+                    val monthMap = mutableMapOf<Int, Double>()
+                    for (record in records) {
+                        try {
+                            val date = LocalDate.parse(record.effectdateStr.substringBefore(" "))
+                            val month = date.monthValue
+                            monthMap[month] = (monthMap[month] ?: 0.0) + ((record.tranamt ?: 0) / 100.0)
+                        } catch (_: Exception) {}
+                    }
+                    monthMap.toList().sortedByDescending { it.second }
+                }
+                val busiestMonth = monthStats.firstOrNull()
+
                 // 早午晚餐分类
                 val mealGroups = remember(records) {
                     records.groupBy { classifyMeal(it.resume, it.jndatetimeStr) }
@@ -243,6 +257,35 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                     }
                 }
 
+                // 哪个月消费最多
+                val monthChartData = remember(monthStats) {
+                    monthStats.sortedBy { it.first }.associate { (month, amount) ->
+                        "${month}月" to amount.toFloat()
+                    }
+                }
+
+                if (monthStats.isNotEmpty()) {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("月份分析") },
+                            headlineContent = { Text("哪个月最能花", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        BarChart(
+                            data = monthChartData,
+                            modifier = Modifier.padding(horizontal = APP_HORIZONTAL_DP, vertical = 8.dp)
+                        )
+                        monthStats.forEach { (month, amount) ->
+                            TransplantListItem(
+                                headlineContent = { Text("${month}月", style = MaterialTheme.typography.bodyMedium) },
+                                trailingContent = { Text("￥${formatDecimal(amount, 2)}", style = MaterialTheme.typography.bodyMedium) }
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+
+
                 if (weekdayStats.isNotEmpty()) {
                     CustomCard(color = cardNormalColor()) {
                         TransplantListItem(
@@ -293,6 +336,10 @@ fun ExpenseAnalysisSection(vm: NetWorkViewModel, semester: Int) {
                         busiestWeekday?.let { (day, _) ->
                             val dayName = DayOfWeek.of(day).getDisplayName(TextStyle.SHORT, Locale.CHINESE)
                             add("你最能花的一天是周$dayName，小心钱包~")
+                        }
+
+                        busiestMonth?.let { (month, _) ->
+                            add("${month}月是你消费最高的一个月，注意生活费规划哦~")
                         }
 
                         if (avgPerTransaction > 30) add("平均单笔 ￥${formatDecimal(avgPerTransaction, 0)}，偶尔奢侈一下也不错~")

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
@@ -75,19 +75,7 @@ fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
 
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
-                if (dayList.isNotEmpty()) {
-                    CustomCard(color = cardNormalColor()) {
-                        drawLineChart(dayList.take(30).reversed().map { BillMonth(it.first, it.second) }, modifier = Modifier.padding(APP_HORIZONTAL_DP))
-                    }
-                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-                }
 
-                if (monthList.isNotEmpty()) {
-                    CustomCard(color = cardNormalColor()) {
-                        drawLineChart(monthList.reversed().map { BillMonth(it.first, it.second) }, modifier = Modifier.padding(APP_HORIZONTAL_DP))
-                    }
-                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-                }
 
                 CustomCard(color = cardNormalColor()) {
                     TransplantListItem(

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
@@ -1,0 +1,110 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.logic.model.huixin.BillMonth
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.parse.formatDecimal
+import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.ui.screen.card.count.drawLineChart
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+
+@Composable
+fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
+    val uiState by vm.cardPredictedResponse.state.collectAsState()
+
+    val refreshNetwork: suspend () -> Unit = rN@ {
+        if (uiState is UiState.Success) return@rN
+        val auth = prefs.getString("auth", "")
+        if (auth.isNullOrEmpty()) return@rN
+        vm.cardPredictedResponse.clear()
+        vm.getCardPredicted("bearer $auth")
+    }
+
+    LaunchedEffect(Unit) { refreshNetwork() }
+
+    DividerTextExpandedWith("消费报表", false) {
+        when (uiState) {
+            is UiState.Success -> {
+                val data = (uiState as UiState.Success).data
+                val allDayList = data.day.analyzeData.statisticalData.toList()
+                val allMonthList = data.month.analyzeData.statisticalData.toList()
+
+                val termInfo = parseSemesterInt(semester)
+
+                val dayList = if (termInfo == null) allDayList else {
+                    val start = termInfo.dateRangeStart
+                    val end = termInfo.dateRangeEnd
+                    allDayList.filter { it.first.substring(0, 7) >= start && it.first.substring(0, 7) < end }
+                }
+                val monthList = if (termInfo == null) allMonthList else {
+                    val start = termInfo.dateRangeStart
+                    val end = termInfo.dateRangeEnd
+                    allMonthList.filter { it.first >= start && it.first < end }
+                }
+
+                val total = dayList.sumOf { it.second }
+                val avg = if (dayList.isEmpty()) 0.0 else total / dayList.size
+                val mAvg = if (monthList.isEmpty()) 0.0 else monthList.sumOf { it.second } / monthList.size
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
+                        headlineContent = { Text("消费概览", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(overlineContent = { Text("总消费") }, headlineContent = { Text("￥${formatDecimal(total, 2)}", style = MaterialTheme.typography.headlineMedium) })
+                    TransplantListItem(overlineContent = { Text("日均") }, headlineContent = { Text("￥${formatDecimal(avg, 2)}", style = MaterialTheme.typography.headlineMedium) })
+                    TransplantListItem(overlineContent = { Text("月均") }, headlineContent = { Text("￥${formatDecimal(mAvg, 2)}", style = MaterialTheme.typography.headlineMedium) })
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                if (dayList.isNotEmpty()) {
+                    drawLineChart(dayList.take(30).reversed().map { BillMonth(it.first, it.second) })
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+
+                if (monthList.isNotEmpty()) {
+                    drawLineChart(monthList.reversed().map { BillMonth(it.first, it.second) })
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                }
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("消费预测") },
+                        headlineContent = { Text("明日预计") },
+                        trailingContent = { Text("￥${formatDecimal(data.day.predictData.predict, 2)}", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(
+                        headlineContent = { Text("下月预计") },
+                        trailingContent = { Text("￥${formatDecimal(data.month.predictData.predict, 2)}", style = MaterialTheme.typography.titleMedium) }
+                    )
+                }
+            }
+            is UiState.Error -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("暂无消费数据") }, supportingContent = { Text("请先在一卡通页面加载数据") })
+                }
+            }
+            else -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("加载中...") })
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
@@ -8,10 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
-import com.hfut.schedule.logic.model.huixin.BillMonth
 import com.hfut.schedule.logic.util.network.state.UiState
 import com.hfut.schedule.logic.util.parse.formatDecimal
 import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
@@ -20,10 +17,7 @@ import com.hfut.schedule.ui.component.container.CustomCard
 import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
-import com.hfut.schedule.ui.screen.card.count.drawLineChart
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
-import androidx.compose.foundation.layout.padding
-import com.xah.common.ui.style.APP_HORIZONTAL_DP
 
 @Composable
 fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
@@ -43,38 +37,6 @@ fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
         when (uiState) {
             is UiState.Success -> {
                 val data = (uiState as UiState.Success).data
-                val allDayList = data.day.analyzeData.statisticalData.toList()
-                val allMonthList = data.month.analyzeData.statisticalData.toList()
-
-                val termInfo = parseSemesterInt(semester)
-
-                val dayList = if (termInfo == null) allDayList else {
-                    val start = termInfo.dateRangeStart
-                    val end = termInfo.dateRangeEnd
-                    allDayList.filter { it.first.substring(0, 7) >= start && it.first.substring(0, 7) < end }
-                }
-                val monthList = if (termInfo == null) allMonthList else {
-                    val start = termInfo.dateRangeStart
-                    val end = termInfo.dateRangeEnd
-                    allMonthList.filter { it.first >= start && it.first < end }
-                }
-
-                val total = dayList.sumOf { it.second }
-                val avg = if (dayList.isEmpty()) 0.0 else total / dayList.size
-                val mAvg = if (monthList.isEmpty()) 0.0 else monthList.sumOf { it.second } / monthList.size
-
-                CustomCard(color = cardNormalColor()) {
-                    TransplantListItem(
-                        overlineContent = { Text(termInfo?.displayName ?: "全部学期") },
-                        headlineContent = { Text("消费概览", style = MaterialTheme.typography.titleMedium) }
-                    )
-                    TransplantListItem(overlineContent = { Text("总消费") }, headlineContent = { Text("￥${formatDecimal(total, 2)}", style = MaterialTheme.typography.headlineMedium) })
-                    TransplantListItem(overlineContent = { Text("日均") }, headlineContent = { Text("￥${formatDecimal(avg, 2)}", style = MaterialTheme.typography.headlineMedium) })
-                    TransplantListItem(overlineContent = { Text("月均") }, headlineContent = { Text("￥${formatDecimal(mAvg, 2)}", style = MaterialTheme.typography.headlineMedium) })
-                }
-
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
 
 
                 CustomCard(color = cardNormalColor()) {

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/ExpenseReportSection.kt
@@ -22,6 +22,8 @@ import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
 import com.hfut.schedule.ui.screen.card.count.drawLineChart
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import androidx.compose.foundation.layout.padding
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
 
 @Composable
 fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
@@ -74,12 +76,16 @@ fun ExpenseReportSection(vm: NetWorkViewModel, semester: Int) {
                 Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
 
                 if (dayList.isNotEmpty()) {
-                    drawLineChart(dayList.take(30).reversed().map { BillMonth(it.first, it.second) })
+                    CustomCard(color = cardNormalColor()) {
+                        drawLineChart(dayList.take(30).reversed().map { BillMonth(it.first, it.second) }, modifier = Modifier.padding(APP_HORIZONTAL_DP))
+                    }
                     Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
                 }
 
                 if (monthList.isNotEmpty()) {
-                    drawLineChart(monthList.reversed().map { BillMonth(it.first, it.second) })
+                    CustomCard(color = cardNormalColor()) {
+                        drawLineChart(monthList.reversed().map { BillMonth(it.first, it.second) }, modifier = Modifier.padding(APP_HORIZONTAL_DP))
+                    }
                     Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
                 }
 

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/LibraryReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/LibraryReportSection.kt
@@ -1,0 +1,145 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.storage.kv.SharedPrefs
+import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.xah.common.ui.component.chart.PieChart
+import com.xah.common.ui.component.chart.PieChartData
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
+
+@Composable
+fun LibraryReportSection(vm: NetWorkViewModel) {
+    val libraryStatus by vm.libraryStatusResp.state.collectAsState()
+    val borrowedBooks by vm.libraryBorrowedResp.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        val token = prefs.getString(SharedPrefs.LIBRARY_TOKEN, "") ?: ""
+        if (token.isNotEmpty() && libraryStatus !is UiState.Success) {
+            vm.libraryStatusResp.clear()
+            vm.getLibraryStatus(token)
+        }
+    }
+
+    DividerTextExpandedWith("图书馆报表", false) {
+        val token = prefs.getString(SharedPrefs.LIBRARY_TOKEN, "") ?: ""
+        if (token.isEmpty()) {
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    headlineContent = { Text("未登录图书馆") },
+                    supportingContent = { Text("请先通过CAS登录图书馆后再查看") }
+                )
+            }
+            return@DividerTextExpandedWith
+        }
+
+        when (libraryStatus) {
+            is UiState.Success -> {
+                val status = (libraryStatus as UiState.Success).data
+
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("图书馆概览") },
+                        headlineContent = {
+                            Text("本学期借阅", style = MaterialTheme.typography.titleMedium)
+                        }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("借阅次数") },
+                        headlineContent = {
+                            Text("${status.borrowCount}", style = MaterialTheme.typography.headlineMedium)
+                        }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("书架藏书") },
+                        headlineContent = {
+                            Text("${status.bookShelfCount}", style = MaterialTheme.typography.headlineMedium)
+                        }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("预约次数") },
+                        headlineContent = {
+                            Text("${status.reserveCount}", style = MaterialTheme.typography.headlineMedium)
+                        }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+
+                if (status.borrowCount > 0 || status.reserveCount > 0 || status.entrustCount > 0) {
+                    CustomCard(color = cardNormalColor()) {
+                        PieChart(
+                            data = listOf(
+                                PieChartData("借阅", status.borrowCount.toFloat()),
+                                PieChartData("预约", status.reserveCount.toFloat()),
+                                PieChartData("委托", status.entrustCount.toFloat())
+                            ).filter { it.value > 0 },
+                            modifier = Modifier.padding(APP_HORIZONTAL_DP),
+                            title = "借阅统计"
+                        )
+                    }
+                }
+
+                when (borrowedBooks) {
+                    is UiState.Success -> {
+                        val books = (borrowedBooks as UiState.Success).data
+                        if (books.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                            CustomCard(color = cardNormalColor()) {
+                                TransplantListItem(
+                                    overlineContent = { Text("当前借阅") },
+                                    headlineContent = {
+                                        Text("共 ${books.size} 本", style = MaterialTheme.typography.titleMedium)
+                                    }
+                                )
+                                books.take(5).forEach { book ->
+                                    TransplantListItem(
+                                        headlineContent = { Text(book.libraryDetail.detail.title) },
+                                        supportingContent = { Text(book.libraryDetail.detail.authors) }
+                                    )
+                                }
+                                if (books.size > 5) {
+                                    TransplantListItem(
+                                        headlineContent = {
+                                            Text("...还有 ${books.size - 5} 本", style = MaterialTheme.typography.bodySmall)
+                                        }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    else -> {}
+                }
+            }
+            is UiState.Error -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        headlineContent = { Text("加载失败") },
+                        supportingContent = { Text("图书馆服务暂时不可用") }
+                    )
+                }
+            }
+            else -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("加载中...") })
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/LibraryReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/LibraryReportSection.kt
@@ -3,6 +3,12 @@ package com.hfut.schedule.ui.screen.report
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -60,39 +66,52 @@ fun LibraryReportSection(vm: NetWorkViewModel) {
                             Text("本学期借阅", style = MaterialTheme.typography.titleMedium)
                         }
                     )
-                    TransplantListItem(
-                        overlineContent = { Text("借阅次数") },
-                        headlineContent = {
-                            Text("${status.borrowCount}", style = MaterialTheme.typography.headlineMedium)
+                    
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = APP_HORIZONTAL_DP),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            TransplantListItem(
+                                overlineContent = { Text("借阅次数", style = MaterialTheme.typography.bodySmall) },
+                                headlineContent = {
+                                    Text("${status.borrowCount}", style = MaterialTheme.typography.headlineSmall)
+                                },
+                                usePadding = false,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                            TransplantListItem(
+                                overlineContent = { Text("书架藏书", style = MaterialTheme.typography.bodySmall) },
+                                headlineContent = {
+                                    Text("${status.bookShelfCount}", style = MaterialTheme.typography.headlineSmall)
+                                },
+                                usePadding = false,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                            TransplantListItem(
+                                overlineContent = { Text("预约次数", style = MaterialTheme.typography.bodySmall) },
+                                headlineContent = {
+                                    Text("${status.reserveCount}", style = MaterialTheme.typography.headlineSmall)
+                                },
+                                usePadding = false,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
                         }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("书架藏书") },
-                        headlineContent = {
-                            Text("${status.bookShelfCount}", style = MaterialTheme.typography.headlineMedium)
+                        
+                        if (status.borrowCount > 0 || status.reserveCount > 0 || status.entrustCount > 0) {
+                            Box(modifier = Modifier.weight(1.5f)) {
+                                PieChart(
+                                    data = listOf(
+                                        PieChartData("借阅", status.borrowCount.toFloat()),
+                                        PieChartData("预约", status.reserveCount.toFloat()),
+                                        PieChartData("委托", status.entrustCount.toFloat())
+                                    ).filter { it.value > 0 },
+                                    modifier = Modifier.fillMaxWidth().height(160.dp),
+                                    pieModifier = Modifier.size(120.dp),
+                                    title = "借阅统计"
+                                )
+                            }
                         }
-                    )
-                    TransplantListItem(
-                        overlineContent = { Text("预约次数") },
-                        headlineContent = {
-                            Text("${status.reserveCount}", style = MaterialTheme.typography.headlineMedium)
-                        }
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
-
-                if (status.borrowCount > 0 || status.reserveCount > 0 || status.entrustCount > 0) {
-                    CustomCard(color = cardNormalColor()) {
-                        PieChart(
-                            data = listOf(
-                                PieChartData("借阅", status.borrowCount.toFloat()),
-                                PieChartData("预约", status.reserveCount.toFloat()),
-                                PieChartData("委托", status.entrustCount.toFloat())
-                            ).filter { it.value > 0 },
-                            modifier = Modifier.padding(APP_HORIZONTAL_DP),
-                            title = "借阅统计"
-                        )
                     }
                 }
 

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/LifeReportSection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/LifeReportSection.kt
@@ -1,0 +1,132 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.logic.util.network.state.UiState
+import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
+import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+
+@Composable
+fun LifeReportSection(vm: NetWorkViewModel, semester: Int) {
+    val dormitoryInfo by vm.dormitoryFromCommunityResp.state.collectAsState()
+    val dormitoryUsers by vm.dormitoryInfoFromCommunityResp.state.collectAsState()
+    val dormitoryScore by vm.dormitoryScoreResp.state.collectAsState()
+
+    val termInfo = remember(semester) { parseSemesterInt(semester) }
+
+    LaunchedEffect(Unit) {
+        try {
+            val token = prefs.getString("TOKEN", "") ?: ""
+            if (token.isNotEmpty()) {
+                vm.dormitoryFromCommunityResp.clear()
+                vm.getDormitory(token)
+                vm.dormitoryInfoFromCommunityResp.clear()
+                vm.getDormitoryInfo(token)
+            }
+        } catch (_: Exception) {}
+    }
+
+    LaunchedEffect(semester) {
+        try {
+            val token = prefs.getString("TOKEN", "") ?: ""
+            if (token.isEmpty()) return@LaunchedEffect
+            val semStr = termInfo?.dormitoryName ?: return@LaunchedEffect
+            vm.dormitoryScoreResp.clear()
+            vm.getDormitoryScore(token, null, semStr)
+        } catch (_: Exception) {}
+    }
+
+    DividerTextExpandedWith("生活报表", false) {
+        when (dormitoryInfo) {
+            is UiState.Success -> {
+                val info = (dormitoryInfo as UiState.Success).data
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        overlineContent = { Text("宿舍信息") },
+                        headlineContent = { Text("${info.campus} ${info.dormitory}", style = MaterialTheme.typography.titleMedium) }
+                    )
+                    TransplantListItem(
+                        overlineContent = { Text("房间号") },
+                        headlineContent = { Text(info.room, style = MaterialTheme.typography.headlineMedium) }
+                    )
+                }
+            }
+            is UiState.Error -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("暂无宿舍信息") }, supportingContent = { Text("请先在宿舍页面加载数据") })
+                }
+            }
+            else -> {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("加载宿舍信息中...") })
+                }
+            }
+        }
+
+        when (dormitoryUsers) {
+            is UiState.Success -> {
+                val users = (dormitoryUsers as UiState.Success).data
+                if (users.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("室友") },
+                            headlineContent = { Text("${users.size}人", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        users.forEach { user ->
+                            TransplantListItem(headlineContent = { Text(user.realname) }, supportingContent = { Text(user.username) })
+                        }
+                    }
+                }
+            }
+            else -> {}
+        }
+
+        when (dormitoryScore) {
+            is UiState.Success -> {
+                val scores = (dormitoryScore as UiState.Success).data
+                if (scores.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text("${termInfo?.displayName ?: ""} 卫生评分") },
+                            headlineContent = { Text("卫生评分", style = MaterialTheme.typography.titleMedium) }
+                        )
+                        scores.forEach { score ->
+                            TransplantListItem(
+                                headlineContent = { Text(score.title) },
+                                trailingContent = { Text(score.value, style = MaterialTheme.typography.titleMedium) }
+                            )
+                        }
+                    }
+                } else {
+                    Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(headlineContent = { Text("暂无卫生评分数据") })
+                    }
+                }
+            }
+            is UiState.Error -> {
+                Spacer(modifier = Modifier.height(CARD_NORMAL_DP))
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(headlineContent = { Text("卫生评分加载失败") }, supportingContent = { Text("请确认已通过CAS登录社区") })
+                }
+            }
+            else -> {}
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
@@ -1,0 +1,83 @@
+package com.hfut.schedule.ui.screen.report
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MediumTopAppBar
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import com.hfut.schedule.logic.util.parse.SemesterParser
+import com.hfut.schedule.ui.component.button.TopBarNavigationIcon
+import com.hfut.schedule.ui.component.screen.pager.PageController
+import com.hfut.schedule.ui.nav.destination.TermReportDestination
+import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.xah.common.ui.style.color.topBarTransplantColor
+import com.xah.common.ui.style.padding.InnerPaddingHeight
+import dev.chrisbanes.haze.hazeSource
+import dev.chrisbanes.haze.rememberHazeState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TermReportScreen(vm: NetWorkViewModel) {
+    val hazeState = rememberHazeState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
+    val listState = rememberLazyListState()
+
+    val defaultSemester = SemesterParser.getSemesterWithoutSuspend()
+    var semester by androidx.compose.runtime.remember { mutableIntStateOf(defaultSemester) }
+    var resetSemester by androidx.compose.runtime.remember { mutableIntStateOf(defaultSemester) }
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            MediumTopAppBar(
+                scrollBehavior = scrollBehavior,
+                modifier = Modifier.hazeSource(hazeState),
+                colors = topBarTransplantColor(),
+                title = { Text(TermReportDestination.title.asString()) },
+                navigationIcon = { TopBarNavigationIcon() }
+            )
+        }
+    ) { innerPadding ->
+        Box(modifier = Modifier.fillMaxSize()) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                item { InnerPaddingHeight(innerPadding, true) }
+                item {
+                    AcademicReportSection(vm, semester) { latestSemester ->
+                        if (latestSemester != resetSemester) {
+                            semester = latestSemester
+                            resetSemester = latestSemester
+                        }
+                    }
+                }
+                item { ExpenseReportSection(vm, semester) }
+                item { LibraryReportSection(vm) }
+                item { LifeReportSection(vm, semester) }
+                item { InnerPaddingHeight(innerPadding, false) }
+            }
+
+            PageController(
+                modifier = Modifier.padding(innerPadding),
+                listState = listState,
+                currentPage = semester,
+                onNextPage = { semester = it },
+                onPreviousPage = { semester = it },
+                gap = 20,
+                text = parseSemesterInt(semester)?.displayName ?: "",
+                range = Pair(null, null),
+                paddingSafely = false,
+                resetPage = resetSemester
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
@@ -60,7 +60,9 @@ fun TermReportScreen(vm: NetWorkViewModel) {
                         }
                     }
                 }
+                item { AcademicAnalysisSection(vm, semester) }
                 item { ExpenseReportSection(vm, semester) }
+                item { ExpenseAnalysisSection(vm, semester) }
                 item { LibraryReportSection(vm) }
                 item { LifeReportSection(vm, semester) }
                 item { InnerPaddingHeight(innerPadding, false) }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/TermReportScreen.kt
@@ -61,7 +61,6 @@ fun TermReportScreen(vm: NetWorkViewModel) {
                     }
                 }
                 item { AcademicAnalysisSection(vm, semester) }
-                item { ExpenseReportSection(vm, semester) }
                 item { ExpenseAnalysisSection(vm, semester) }
                 item { LibraryReportSection(vm) }
                 item { LifeReportSection(vm, semester) }

--- a/app/src/main/java/com/hfut/schedule/ui/screen/report/TermUtils.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/report/TermUtils.kt
@@ -1,0 +1,34 @@
+package com.hfut.schedule.ui.screen.report
+
+data class TermInfo(val startYear: Int, val endYear: Int, val termNum: Int) {
+    val displayName = "$startYear-$endYear $termNum"
+    val dormitoryName = "${startYear}-${endYear}学年第${if (termNum == 1) "一" else "二"}学期"
+    val dateRangeStart = if (termNum == 1) "$startYear-09" else "$endYear-02"
+    val dateRangeEnd = if (termNum == 1) "$endYear-02" else "$endYear-09"
+}
+
+fun parseSemesterInt(semester: Int): TermInfo? {
+    return try {
+        val codes = (semester - 4) / 10
+        val startYear = 2018 + (codes + 1) / 4
+        val endYear = startYear + 1
+        val termNum = if (codes % 4 == 1) 2 else if (codes % 4 == 3) 1 else 0
+        if (termNum == 0) null
+        else TermInfo(startYear, endYear, termNum)
+    } catch (_: Exception) { null }
+}
+
+fun termStringToSemesterInt(term: String): Int? {
+    return try {
+        val years = Regex("(\\d{4})[^\\d]+(\\d{4})").find(term) ?: return null
+        val y1 = years.groupValues[1].toInt()
+        val hasTwo = Regex("[2二]").containsMatchIn(term.substringAfter(years.value))
+        val termNum = if (hasTwo) 2 else 1
+        val codes = (y1 - 2019) * 4 + (if (termNum == 2) 5 else 3)
+        codes * 10 + 4
+    } catch (_: Exception) { null }
+}
+
+fun latestSemesterFromTerms(terms: List<String>): Int? {
+    return terms.mapNotNull { termStringToSemesterInt(it) }.maxOrNull()
+}

--- a/app/src/main/res/values-zh-rCN/strings_navigation_label.xml
+++ b/app/src/main/res/values-zh-rCN/strings_navigation_label.xml
@@ -91,4 +91,5 @@
     <string name="navigation_label_settings_corner">屏幕圆角校准</string>
     <string name="navigation_label_shortcut">Shortcut</string>
     <string name="navigation_label_live_update">实时通知</string>
+    <string name="navigation_label_term_report">学期报表</string>
 </resources>

--- a/app/src/main/res/values/strings_navigation_label.xml
+++ b/app/src/main/res/values/strings_navigation_label.xml
@@ -91,4 +91,5 @@
     <string name="navigation_label_settings_corner">Screen corner</string>
     <string name="navigation_label_shortcut">Shortcut</string>
     <string name="navigation_label_live_update">Live Update</string>
+    <string name="navigation_label_term_report">Term Report</string>
 </resources>

--- a/common/src/main/java/com/xah/common/ui/component/chart/BarChart.kt
+++ b/common/src/main/java/com/xah/common/ui/component/chart/BarChart.kt
@@ -50,7 +50,7 @@ fun BarChart(
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Bottom,
-                    modifier = Modifier.weight(1f, fill = true)
+                    modifier = Modifier.weight(1f, fill = true).fillMaxHeight()
                 ) {
                     // 上方数值标签
                     if (showLabel) {

--- a/common/src/main/java/com/xah/common/ui/component/chart/BarChart.kt
+++ b/common/src/main/java/com/xah/common/ui/component/chart/BarChart.kt
@@ -55,20 +55,22 @@ fun BarChart(
                     // 上方数值标签
                     if (showLabel) {
                         Text(
-                            text = value.toString(),
+                            text = if (value % 1f == 0f) value.toInt().toString() else value.toString(),
                             style = MaterialTheme.typography.labelSmall,
                             color = labelColor
                         )
                     }
 
-                    // 柱子
-                    Box(
-                        modifier = Modifier
-                            .padding(vertical = 4.dp)
-                            .fillMaxWidth(0.6f)
-                            .fillMaxHeight(ratio)
-                            .background(barColor, shape = RoundedCornerShape(4.dp))
-                    )
+                    // 柱子区域
+                    Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.BottomCenter) {
+                        Box(
+                            modifier = Modifier
+                                .padding(vertical = 4.dp)
+                                .fillMaxWidth(0.6f)
+                                .fillMaxHeight(ratio)
+                                .background(barColor, shape = RoundedCornerShape(4.dp))
+                        )
+                    }
 
                     // 下方标签
                     if (showLabel) {

--- a/common/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
+++ b/common/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
@@ -34,7 +34,9 @@ fun LineChart(
     modifier: Modifier = Modifier,
     showLabel : Boolean = false,
     title : String? = null,
-    lineColor: Color = MaterialTheme.colorScheme.primary
+    lineColor: Color = MaterialTheme.colorScheme.primary,
+    yAxisFormatter: (Float) -> String = { it.toString() },
+    xLabelSpacing: Int = 1
 ) {
     if (data.isEmpty()) return
 
@@ -112,9 +114,10 @@ fun LineChart(
                         .align(Alignment.BottomCenter),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    xLabels.forEach { label ->
+                    xLabels.forEachIndexed { index, label ->
+                        val showThisLabel = (index % xLabelSpacing == 0) || (index == xLabels.size - 1)
                         Text(
-                            text = label,
+                            text = if (showThisLabel) label else "",
                             style = MaterialTheme.typography.labelSmall,
                             textAlign = TextAlign.Center,
                             modifier = Modifier.width(IntrinsicSize.Min)
@@ -128,9 +131,9 @@ fun LineChart(
                         .align(Alignment.CenterStart),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(text = maxY.toString(), style = MaterialTheme.typography.labelSmall)
+                    Text(text = yAxisFormatter(maxY), style = MaterialTheme.typography.labelSmall)
                     Spacer(modifier = Modifier.height(4.dp))
-                    Text(text = minY.toString(), style = MaterialTheme.typography.labelSmall)
+                    Text(text = yAxisFormatter(minY), style = MaterialTheme.typography.labelSmall)
                 }
             }
         }


### PR DESCRIPTION
#28 校园网用量App本地好像没有存,暂时不实现。
已实现：
- 学业报表
- 各学期GPA
- 学业分析（最好和最差科目）
- 学业数据图表
- 学分分布
- 绩点分布
- 消费分析(早中晚分时统计)
- 最常消费地点top5(几个食堂)
- 总消费(学期总消费,日均,月均,单笔均,最早的消费时间\最晚的消费时间)
- 哪个月最能花?
- 一周内哪天最能花?
- 图书馆借阅

已知问题:
- 最繁忙的一周在任何学期都出现且只显示最新学期的内容(只能拉到最新学期的课表)

<img width="565" height="1244" alt="image" src="https://github.com/user-attachments/assets/a258d3b5-cd07-4784-b578-a450d72de11a" />
<img width="570" height="1254" alt="image" src="https://github.com/user-attachments/assets/67700202-6969-4ac6-934e-3092e302568c" />
<img width="567" height="1076" alt="image" src="https://github.com/user-attachments/assets/5a311e6a-86b8-479c-a54a-b20b2648eecc" />
<img width="581" height="1147" alt="image" src="https://github.com/user-attachments/assets/b8728001-c173-46f0-9e08-6d7556d1d374" />
<img width="560" height="1228" alt="image" src="https://github.com/user-attachments/assets/b5266460-d25a-4e2c-97a0-3f119c066657" />
