### PR TITLE
feature：LineChart 折线图交互-点击详情

### DIFF
--- a/common-ui/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
+++ b/common-ui/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
@@ -65,6 +65,7 @@ fun LineChart(
     val xAxisHeight = if (showLabel) 36.dp else 0.dp
     val chartTopPadding = if (showLabel) 8.dp else 0.dp
     val chartHorizontalPadding = if (showLabel) 24.dp else 0.dp
+    val selectedPointCenterColor = MaterialTheme.colorScheme.surface
     var selectedIndex by remember(data) { mutableIntStateOf(-1) }
 
     ColumnVertical {
@@ -204,6 +205,36 @@ fun LineChart(
                         radius = 2.dp.toPx(),
                         center = point,
                         style = Stroke(width = 1.dp.toPx())
+                    )
+                }
+                if (selectedIndex in points.indices) {
+                    val selectedPoint = points[selectedIndex]
+                    drawLine(
+                        color = lineColor.copy(alpha = 0.35f),
+                        start = Offset(selectedPoint.x, chartTop),
+                        end = Offset(selectedPoint.x, chartBottom),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                    drawCircle(
+                        color = lineColor.copy(alpha = 0.18f),
+                        radius = 11.dp.toPx(),
+                        center = selectedPoint
+                    )
+                    drawCircle(
+                        color = selectedPointCenterColor,
+                        radius = 7.dp.toPx(),
+                        center = selectedPoint
+                    )
+                    drawCircle(
+                        color = lineColor,
+                        radius = 7.dp.toPx(),
+                        center = selectedPoint,
+                        style = Stroke(width = 2.dp.toPx())
+                    )
+                    drawCircle(
+                        color = lineColor,
+                        radius = 3.dp.toPx(),
+                        center = selectedPoint
                     )
                 }
             }

--- a/common-ui/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
+++ b/common-ui/src/main/java/com/xah/common/ui/component/chart/LineChart.kt
@@ -1,11 +1,12 @@
 package com.xah.common.ui.component.chart
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.background
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -14,18 +15,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.xah.common.ui.style.align.ColumnVertical
+import kotlin.math.hypot
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
@@ -36,52 +47,133 @@ fun LineChart(
     title : String? = null,
     lineColor: Color = MaterialTheme.colorScheme.primary,
     yAxisFormatter: (Float) -> String = { it.toString() },
-    xLabelSpacing: Int = 1
+    xAxisFormatter: (String) -> String = { it },
+    xLabelSpacing: Int = 1,
+    maxXLabelCount: Int = 4
 ) {
     if (data.isEmpty()) return
 
     val xLabels = data.keys.toList()
     val yValues = data.values.toList()
+    val safeXLabelSpacing = xLabelSpacing.coerceAtLeast(1)
 
     val maxY = yValues.maxOrNull() ?: 1f
     val minY = yValues.minOrNull() ?: 0f
     val yRange = (maxY - minY).takeIf { it != 0f } ?: 1f
+    val density = LocalDensity.current
+    val yAxisWidth = if (showLabel) 54.dp else 0.dp
+    val xAxisHeight = if (showLabel) 36.dp else 0.dp
+    val chartTopPadding = if (showLabel) 8.dp else 0.dp
+    val chartHorizontalPadding = if (showLabel) 24.dp else 0.dp
+    var selectedIndex by remember(data) { mutableIntStateOf(-1) }
 
     ColumnVertical {
-        BoxWithConstraints(modifier = modifier.padding(horizontal = 16.dp)) {
+        BoxWithConstraints(modifier = modifier.padding(horizontal = 8.dp)) {
             val width = constraints.maxWidth.toFloat()
             val height = constraints.maxHeight.toFloat()
+            val visibleLabels = if (showLabel) {
+                val safeMaxLabelCount = maxXLabelCount.coerceAtLeast(2)
+                val readableSpacing = ((xLabels.size + safeMaxLabelCount - 1) / safeMaxLabelCount).coerceAtLeast(1)
+                val finalSpacing = maxOf(safeXLabelSpacing, readableSpacing)
+                val indexes = xLabels.indices.filter { index ->
+                    index == 0 || index == xLabels.lastIndex || index % finalSpacing == 0
+                }.let { indexes ->
+                    if (indexes.size <= safeMaxLabelCount) {
+                        indexes
+                    } else {
+                        buildList {
+                            add(indexes.first())
+                            val middleCount = safeMaxLabelCount - 2
+                            if (middleCount > 0) {
+                                val middleIndexes = indexes.drop(1).dropLast(1)
+                                repeat(middleCount) { item ->
+                                    val targetIndex = ((item + 1) * middleIndexes.size / (middleCount + 1))
+                                        .coerceIn(0, (middleIndexes.size - 1).coerceAtLeast(0))
+                                    middleIndexes.getOrNull(targetIndex)?.let(::add)
+                                }
+                            }
+                            add(indexes.last())
+                        }.distinct()
+                    }
+                }
+                indexes.map { xAxisFormatter(xLabels[it]) }
+            } else {
+                emptyList()
+            }
 
-            Canvas(modifier = Modifier.fillMaxSize()) {
-                val xStep = width / (xLabels.size - 1).coerceAtLeast(1)
-                val yRatio = height / yRange
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(data, width, height, showLabel) {
+                        detectTapGestures { tap ->
+                            val xAxisHeightPx = with(density) { xAxisHeight.toPx() }
+                            val chartTopPaddingPx = with(density) { chartTopPadding.toPx() }
+                            val chartHorizontalPaddingPx = with(density) { chartHorizontalPadding.toPx() }
+                            val chartLeft = chartHorizontalPaddingPx
+                            val chartTop = chartTopPaddingPx
+                            val chartRight = (width - chartHorizontalPaddingPx).coerceAtLeast(chartLeft)
+                            val chartBottom = (height - xAxisHeightPx).coerceAtLeast(chartTop)
+                            val chartWidth = (chartRight - chartLeft).coerceAtLeast(1f)
+                            val chartHeight = (chartBottom - chartTop).coerceAtLeast(1f)
+                            val xStep = chartWidth / (xLabels.size - 1).coerceAtLeast(1)
+                            val yRatio = chartHeight / yRange
+                            val points = yValues.mapIndexed { index, y ->
+                                Offset(
+                                    x = chartLeft + index * xStep,
+                                    y = chartBottom - (y - minY) * yRatio
+                                )
+                            }
+                            val hitRadius = with(density) { 28.dp.toPx() }
+                            val nearest = points
+                                .mapIndexed { index, point ->
+                                    index to hypot(tap.x - point.x, tap.y - point.y)
+                                }
+                                .minByOrNull { it.second }
+                            selectedIndex = if (nearest != null && nearest.second <= hitRadius) nearest.first else -1
+                        }
+                    }
+            ) {
+                val xAxisHeightPx = with(density) { xAxisHeight.toPx() }
+                val chartTopPaddingPx = with(density) { chartTopPadding.toPx() }
+                val chartHorizontalPaddingPx = with(density) { chartHorizontalPadding.toPx() }
+                val chartLeft = chartHorizontalPaddingPx
+                val chartTop = chartTopPaddingPx
+                val chartRight = (width - chartHorizontalPaddingPx).coerceAtLeast(chartLeft)
+                val chartBottom = (height - xAxisHeightPx).coerceAtLeast(chartTop)
+                val chartWidth = (chartRight - chartLeft).coerceAtLeast(1f)
+                val chartHeight = (chartBottom - chartTop).coerceAtLeast(1f)
+                val xStep = chartWidth / (xLabels.size - 1).coerceAtLeast(1)
+                val yRatio = chartHeight / yRange
 
                 // 画 X/Y 坐标轴
                 drawLine(
                     color = Color.Gray,
-                    start = Offset(0f, height),
-                    end = Offset(width, height),
+                    start = Offset(chartLeft, chartBottom),
+                    end = Offset(chartRight, chartBottom),
                     strokeWidth = 2f
                 )
                 drawLine(
                     color = Color.Gray,
-                    start = Offset(0f, 0f),
-                    end = Offset(0f, height),
+                    start = Offset(chartLeft, chartTop),
+                    end = Offset(chartLeft, chartBottom),
                     strokeWidth = 2f
                 )
 
                 // 计算折线点
                 val points = yValues.mapIndexed { index, y ->
-                    Offset(x = index * xStep, y = height - (y - minY) * yRatio)
+                    Offset(
+                        x = chartLeft + index * xStep,
+                        y = chartBottom - (y - minY) * yRatio
+                    )
                 }
 
                 // 阴影区域填充
                 val fillPath = Path().apply {
-                    moveTo(points.first().x, height)
+                    moveTo(points.first().x, chartBottom)
                     points.forEach { point ->
                         lineTo(point.x, point.y)
                     }
-                    lineTo(points.last().x, height)
+                    lineTo(points.last().x, chartBottom)
                     close()
                 }
 //                drawPath(
@@ -105,22 +197,35 @@ fun LineChart(
                 points.zipWithNext { a, b ->
                     drawLine(color = lineColor, start = a, end = b, strokeWidth = 3f)
                 }
+                points.forEach { point ->
+                    drawCircle(color = lineColor, radius = 4.dp.toPx(), center = point)
+                    drawCircle(
+                        color = Color.White,
+                        radius = 2.dp.toPx(),
+                        center = point,
+                        style = Stroke(width = 1.dp.toPx())
+                    )
+                }
             }
             if(showLabel) {
                 // 绘制X轴标签
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .height(xAxisHeight)
+                        .padding(horizontal = chartHorizontalPadding)
                         .align(Alignment.BottomCenter),
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
-                    xLabels.forEachIndexed { index, label ->
-                        val showThisLabel = (index % xLabelSpacing == 0) || (index == xLabels.size - 1)
+                    visibleLabels.forEach { label ->
                         Text(
-                            text = if (showThisLabel) label else "",
+                            text = label,
                             style = MaterialTheme.typography.labelSmall,
                             textAlign = TextAlign.Center,
-                            modifier = Modifier.width(IntrinsicSize.Min)
+                            maxLines = 1,
+                            overflow = TextOverflow.Clip,
+                            softWrap = false,
+                            modifier = Modifier.width(48.dp)
                         )
                     }
                 }
@@ -128,13 +233,39 @@ fun LineChart(
                 Column(
                     modifier = Modifier
                         .fillMaxHeight()
+                        .width(yAxisWidth)
+                        .padding(bottom = xAxisHeight, top = chartTopPadding)
                         .align(Alignment.CenterStart),
                     verticalArrangement = Arrangement.SpaceBetween
                 ) {
-                    Text(text = yAxisFormatter(maxY), style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        text = yAxisFormatter(maxY),
+                        style = MaterialTheme.typography.labelSmall,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                     Spacer(modifier = Modifier.height(4.dp))
-                    Text(text = yAxisFormatter(minY), style = MaterialTheme.typography.labelSmall)
+                    Text(
+                        text = yAxisFormatter(minY),
+                        style = MaterialTheme.typography.labelSmall,
+                        textAlign = TextAlign.End,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
+            }
+            if (selectedIndex in yValues.indices) {
+                Text(
+                    text = "${xAxisFormatter(xLabels[selectedIndex])}  ${yAxisFormatter(yValues[selectedIndex])}",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .background(
+                            MaterialTheme.colorScheme.secondaryContainer,
+                            RoundedCornerShape(8.dp)
+                        )
+                        .padding(horizontal = 10.dp, vertical = 4.dp)
+                )
             }
         }
         title?.let { Text(it) }


### PR DESCRIPTION
## 变更内容

- 为 `LineChart` 增加点击/触摸点位后的详情提示。
- 优化 X/Y 轴标签留白和可读性，避免标签挤压图表区域。
- 在当前选中的数据点上绘制辅助线、外圈和内点高亮，便于确认详情对应的具体点位。

## 影响

这个 PR 只修改 `common-ui/src/main/java/com/xah/common/ui/component/chart/LineChart.kt`，用于提升通用折线图组件的交互反馈。

## 验证

- `sh gradlew :app:compileDebugKotlin` 通过。
- 编译过程中仍有项目既有的 KSP/Room 和 deprecation warning

<img width="632" height="686" alt="image" src="https://github.com/user-attachments/assets/46bc3a86-cd6b-487a-82e6-ecad34ce4c0f" />
<img width="636" height="424" alt="image" src="https://github.com/user-attachments/assets/8045d482-8301-4816-a8ab-daf61b0e57b8" />
<img width="694" height="520" alt="image" src="https://github.com/user-attachments/assets/7d22aab4-4892-42a3-8c06-1b5c6703a94b" />
