### PR TITLE
Feature：电费本地历史查询

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,13 +250,13 @@ dependencies {
         implementation(libs.sharednav)
     }
     // 共用UI模块
-    implementation implementation(project(':common-ui'))
+    implementation(project(':common-ui'))
     // 共用逻辑模块
-    implementation implementation(project(':common-logic'))
+    implementation(project(':common-logic'))
     // 消费预测
-    implementation implementation(project(':forecast'))
+    implementation(project(':forecast'))
     // 网络
-    implementation implementation(project(':network'))
+    implementation(project(':network'))
     // 基准文件模块
     baselineProfile project(":baselineProfile")
 }

--- a/app/src/main/java/com/hfut/schedule/logic/database/AppDataBase.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/AppDataBase.kt
@@ -4,11 +4,13 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import com.hfut.schedule.logic.database.dao.CustomEventDao
+import com.hfut.schedule.logic.database.dao.ElectricBalanceRecordDao
 import com.hfut.schedule.logic.database.dao.FriendDao
 import com.hfut.schedule.logic.database.dao.ShowerLabelDao
 import com.hfut.schedule.logic.database.dao.SpecialWorkDayDao
 import com.hfut.schedule.logic.database.dao.WebURLDao
 import com.hfut.schedule.logic.database.entity.CustomEventEntity
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
 import com.hfut.schedule.logic.database.entity.FriendEntity
 import com.hfut.schedule.logic.database.entity.ShowerLabelEntity
 import com.hfut.schedule.logic.database.entity.SpecialWorkDayEntity
@@ -16,7 +18,7 @@ import com.hfut.schedule.logic.database.entity.WebURLEntity
 import com.hfut.schedule.logic.database.util.DateTypeConverter
 
 // 每次记得升级数据库
-private const val VERSION = 5
+private const val VERSION = 6
 
 @Database(
     entities = [
@@ -24,7 +26,8 @@ private const val VERSION = 5
         ShowerLabelEntity::class,
         SpecialWorkDayEntity::class,
         WebURLEntity::class,
-        FriendEntity::class
+        FriendEntity::class,
+        ElectricBalanceRecordEntity::class
                ],
     version = VERSION
 )
@@ -35,4 +38,5 @@ abstract class AppDataBase : RoomDatabase() {
     abstract fun specialWorkDayDao() : SpecialWorkDayDao
     abstract fun webUrlDao() : WebURLDao
     abstract fun friendDao() : FriendDao
+    abstract fun electricBalanceRecordDao() : ElectricBalanceRecordDao
 }

--- a/app/src/main/java/com/hfut/schedule/logic/database/DataBaseManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/DataBaseManager.kt
@@ -5,6 +5,7 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.hfut.schedule.application.MyApplication
 import com.hfut.schedule.logic.database.dao.CustomEventDao
+import com.hfut.schedule.logic.database.dao.ElectricBalanceRecordDao
 import com.hfut.schedule.logic.database.dao.FriendDao
 import com.hfut.schedule.logic.database.dao.ShowerLabelDao
 import com.hfut.schedule.logic.database.dao.SpecialWorkDayDao
@@ -61,6 +62,25 @@ private val MIGRATION_4_5 = object : Migration(4, 5) {
         db.execSQL("DROP TABLE IF EXISTS `course`")
     }
 }
+private val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS electric_balance_record (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                meterKey TEXT NOT NULL,
+                campusRegion TEXT NOT NULL,
+                roomName TEXT NOT NULL,
+                remainingBalance REAL NOT NULL,
+                sampledAt INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            "CREATE INDEX IF NOT EXISTS index_electric_balance_record_meterKey_sampledAt ON electric_balance_record(meterKey, sampledAt)"
+        )
+    }
+}
 
 object DataBaseManager {
     private val db: AppDataBase by lazy {
@@ -72,7 +92,8 @@ object DataBaseManager {
             MIGRATION_1_2,
             MIGRATION_2_3,
             MIGRATION_3_4,
-            MIGRATION_4_5
+            MIGRATION_4_5,
+            MIGRATION_5_6
         ).build()
     }
 
@@ -81,4 +102,5 @@ object DataBaseManager {
     val specialWorkDayDao: SpecialWorkDayDao by lazy { db.specialWorkDayDao() }
     val webUrlDao: WebURLDao by lazy { db.webUrlDao() }
     val friendDao: FriendDao by lazy { db.friendDao() }
+    val electricBalanceRecordDao: ElectricBalanceRecordDao by lazy { db.electricBalanceRecordDao() }
 }

--- a/app/src/main/java/com/hfut/schedule/logic/database/dao/ElectricBalanceRecordDao.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/dao/ElectricBalanceRecordDao.kt
@@ -1,0 +1,58 @@
+package com.hfut.schedule.logic.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ElectricBalanceRecordDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(record: ElectricBalanceRecordEntity)
+
+    @Query(
+        """
+        SELECT * FROM electric_balance_record
+        WHERE meterKey = :meterKey
+        ORDER BY sampledAt ASC
+        """
+    )
+    fun observeByMeter(meterKey: String): Flow<List<ElectricBalanceRecordEntity>>
+
+    @Query(
+        """
+        SELECT * FROM electric_balance_record
+        WHERE meterKey = :meterKey
+        ORDER BY sampledAt DESC
+        LIMIT 1
+        """
+    )
+    suspend fun getLatest(meterKey: String): ElectricBalanceRecordEntity?
+
+    @Query(
+        """
+        DELETE FROM electric_balance_record
+        WHERE meterKey = :meterKey
+        """
+    )
+    suspend fun deleteByMeter(meterKey: String)
+
+    @Query(
+        """
+        DELETE FROM electric_balance_record
+        WHERE sampledAt < :before
+        """
+    )
+    suspend fun deleteBefore(before: Long)
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM electric_balance_record
+        WHERE meterKey = :meterKey
+        """
+    )
+    suspend fun countByMeter(meterKey: String): Int
+}

--- a/app/src/main/java/com/hfut/schedule/logic/database/entity/ElectricBalanceRecordEntity.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/entity/ElectricBalanceRecordEntity.kt
@@ -1,0 +1,21 @@
+package com.hfut.schedule.logic.database.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "electric_balance_record",
+    indices = [
+        Index(value = ["meterKey", "sampledAt"])
+    ]
+)
+data class ElectricBalanceRecordEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val meterKey: String,
+    val campusRegion: String,
+    val roomName: String,
+    val remainingBalance: Double,
+    val sampledAt: Long
+)

--- a/app/src/main/java/com/hfut/schedule/logic/database/model/ElectricUsageModels.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/model/ElectricUsageModels.kt
@@ -1,0 +1,34 @@
+package com.hfut.schedule.logic.database.model
+
+data class ElectricConsumptionInterval(
+    val startAt: Long,
+    val endAt: Long,
+    val startBalance: Double,
+    val endBalance: Double,
+    val consumed: Double,
+    val durationDays: Double,
+    val dailyRate: Double
+)
+
+data class ElectricDailyConsumption(
+    val dayStartAt: Long,
+    val consumed: Double
+)
+
+data class ElectricIncreaseEvent(
+    val sampledAt: Long,
+    val amount: Double
+)
+
+data class ElectricUsageSummary(
+    val latestBalance: Double?,
+    val firstSampleAt: Long?,
+    val latestSampleAt: Long?,
+    val totalConsumed: Double,
+    val averageDailyConsumption: Double?,
+    val estimatedRemainingDays: Double?,
+    val validIntervalCount: Int,
+    val increases: List<ElectricIncreaseEvent>,
+    val intervals: List<ElectricConsumptionInterval>,
+    val dailyConsumptions: List<ElectricDailyConsumption>
+)

--- a/app/src/main/java/com/hfut/schedule/logic/database/repository/ElectricHistoryRepository.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/repository/ElectricHistoryRepository.kt
@@ -1,0 +1,109 @@
+package com.hfut.schedule.logic.database.repository
+
+import com.hfut.schedule.logic.database.DataBaseManager
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
+import com.hfut.schedule.logic.database.util.ElectricMeterKeyFactory
+import com.xah.common.logic.util.LogUtil
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+object ElectricHistoryRepository {
+
+    private val dao get() = DataBaseManager.electricBalanceRecordDao
+
+    private const val DUPLICATE_THRESHOLD = 0.005
+    private const val DUPLICATE_TIME_MS = 60 * 60 * 1000L
+    private const val EXPIRE_DAYS = 365
+
+    private val recordMutex = Mutex()
+
+    fun observeHistory(meterKey: String): Flow<List<ElectricBalanceRecordEntity>> {
+        return dao.observeByMeter(meterKey)
+    }
+
+    suspend fun recordSnapshot(
+        meterKey: String,
+        campusRegion: String,
+        roomName: String,
+        balance: Double,
+        sampledAt: Long = System.currentTimeMillis()
+    ): Boolean = recordMutex.withLock {
+        withContext(Dispatchers.IO) {
+            try {
+                if (!ElectricMeterKeyFactory.isValid(meterKey)) {
+                    LogUtil.error("meterKey格式无效，跳过保存: $meterKey")
+                    return@withContext false
+                }
+                if (roomName.isBlank()) {
+                    LogUtil.error("roomName为空，跳过保存")
+                    return@withContext false
+                }
+                if (balance.isNaN() || balance.isInfinite()) {
+                    LogUtil.error("余额数值无效: $balance，跳过保存")
+                    return@withContext false
+                }
+                if (balance < -1000.0) {
+                    LogUtil.error("余额数值异常: $balance，跳过保存")
+                    return@withContext false
+                }
+
+                val latest = dao.getLatest(meterKey)
+                if (latest != null) {
+                    if (sampledAt < latest.sampledAt) {
+                        LogUtil.error("采样时间早于最新记录，跳过保存: meterKey=$meterKey, sampledAt=$sampledAt, latestAt=${latest.sampledAt}")
+                        return@withContext false
+                    }
+                    val balanceDiff = kotlin.math.abs(balance - latest.remainingBalance)
+                    val timeDiff = sampledAt - latest.sampledAt
+                    if (balanceDiff <= DUPLICATE_THRESHOLD && timeDiff in 0 until DUPLICATE_TIME_MS) {
+                        LogUtil.debug("余额未变化且时间间隔过短，跳过保存: meterKey=$meterKey, balance=$balance")
+                        return@withContext false
+                    }
+                }
+
+                val record = ElectricBalanceRecordEntity(
+                    meterKey = meterKey,
+                    campusRegion = campusRegion,
+                    roomName = roomName,
+                    remainingBalance = balance,
+                    sampledAt = sampledAt
+                )
+                dao.insert(record)
+                LogUtil.info("电费余额快照已保存: meterKey=$meterKey, balance=$balance")
+
+                try {
+                    val expireBefore = System.currentTimeMillis() - EXPIRE_DAYS * 24 * 60 * 60 * 1000L
+                    dao.deleteBefore(expireBefore)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    LogUtil.error(e, "清理过期电费记录失败")
+                }
+
+                true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LogUtil.error(e, "保存电费余额快照失败")
+                false
+            }
+        }
+    }
+
+    suspend fun clearHistory(meterKey: String) = recordMutex.withLock {
+        withContext(Dispatchers.IO) {
+            try {
+                dao.deleteByMeter(meterKey)
+                LogUtil.info("已清除电费历史: meterKey=$meterKey")
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LogUtil.error(e, "清除电费历史失败: meterKey=$meterKey")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricBalanceParser.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricBalanceParser.kt
@@ -1,0 +1,62 @@
+package com.hfut.schedule.logic.database.util
+
+import com.hfut.schedule.logic.enumeration.CampusRegion
+import com.xah.common.logic.util.LogUtil
+
+object ElectricBalanceParser {
+
+    private val AMOUNT_REGEX = Regex("""剩余金额[：:\s]*(-?[0-9]+(?:\.[0-9]+)?)""")
+
+    fun parse(rawValue: String?, campusRegion: CampusRegion): Double? {
+        if (rawValue.isNullOrBlank()) return null
+        return when (campusRegion) {
+            CampusRegion.HEFEI -> parseHefeiBalance(rawValue)
+            CampusRegion.XUANCHENG -> parseXuanchengBalance(rawValue)
+        }
+    }
+
+    fun parseHefeiBalance(rawValue: String): Double? {
+        return try {
+            val cleaned = rawValue.trim()
+                .replace("￥", "")
+                .replace("¥", "")
+                .replace(" ", "")
+                .trim()
+            if (cleaned.isEmpty() || cleaned == "XX.XX" || cleaned == "--") {
+                return null
+            }
+            val value = cleaned.toDoubleOrNull()
+            validateBalance(value)
+        } catch (e: Exception) {
+            LogUtil.error(e, "合肥余额解析失败: $rawValue")
+            null
+        }
+    }
+
+    fun parseXuanchengBalance(rawValue: String): Double? {
+        return try {
+            val match = AMOUNT_REGEX.find(rawValue)
+            if (match != null) {
+                val value = match.groupValues[1].toDoubleOrNull()
+                return validateBalance(value)
+            }
+            val cleaned = rawValue.trim()
+                .replace("￥", "")
+                .replace("¥", "")
+                .replace(" ", "")
+                .trim()
+            val value = cleaned.toDoubleOrNull()
+            validateBalance(value)
+        } catch (e: Exception) {
+            LogUtil.error(e, "宣城余额解析失败: $rawValue")
+            null
+        }
+    }
+
+    private fun validateBalance(value: Double?): Double? {
+        if (value == null) return null
+        if (value.isNaN() || value.isInfinite()) return null
+        if (value < -1000.0) return null
+        return value
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricMeterKeyFactory.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricMeterKeyFactory.kt
@@ -1,0 +1,31 @@
+package com.hfut.schedule.logic.database.util
+
+object ElectricMeterKeyFactory {
+
+    fun hefei(buildingNumber: String, roomNumber: String): String {
+        require(buildingNumber.isNotBlank()) { "buildingNumber不能为空" }
+        require(roomNumber.isNotBlank()) { "roomNumber不能为空" }
+        return "HEFEI:${buildingNumber.trim()}:${roomNumber.trim()}"
+    }
+
+    fun xuancheng(input: String): String {
+        require(input.isNotBlank()) { "input不能为空" }
+        return "XUANCHENG:${input.trim()}"
+    }
+
+    fun isValid(key: String): Boolean {
+        return when {
+            key.startsWith("HEFEI:") -> {
+                val parts = key.split(":")
+                parts.size == 3 &&
+                    parts[1].isNotBlank() &&
+                    parts[2].isNotBlank()
+            }
+            key.startsWith("XUANCHENG:") -> {
+                val input = key.removePrefix("XUANCHENG:")
+                input.isNotBlank()
+            }
+            else -> false
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricUsageCalculator.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/database/util/ElectricUsageCalculator.kt
@@ -1,0 +1,220 @@
+package com.hfut.schedule.logic.database.util
+
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
+import com.hfut.schedule.logic.database.model.ElectricConsumptionInterval
+import com.hfut.schedule.logic.database.model.ElectricDailyConsumption
+import com.hfut.schedule.logic.database.model.ElectricIncreaseEvent
+import com.hfut.schedule.logic.database.model.ElectricUsageSummary
+import java.util.Calendar
+
+object ElectricUsageCalculator {
+
+    private const val EPSILON = 0.005
+    private const val MILLIS_PER_DAY = 86_400_000L
+
+    fun calculate(records: List<ElectricBalanceRecordEntity>): ElectricUsageSummary {
+        if (records.isEmpty()) {
+            return emptySummary()
+        }
+
+        val meterKeys = records.map { it.meterKey }.distinct()
+        require(meterKeys.size <= 1) {
+            "ElectricUsageCalculator only accepts records from one meterKey, but got: $meterKeys"
+        }
+
+        val sorted = records.sortedBy { it.sampledAt }
+        val intervals = mutableListOf<ElectricConsumptionInterval>()
+        val increases = mutableListOf<ElectricIncreaseEvent>()
+        val dailyConsumptionMap = linkedMapOf<Long, Double>()
+        var totalConsumed = 0.0
+        var totalDurationDays = 0.0
+
+        for (i in 1 until sorted.size) {
+            val prev = sorted[i - 1]
+            val curr = sorted[i]
+
+            if (curr.sampledAt <= prev.sampledAt) continue
+
+            val diff = prev.remainingBalance - curr.remainingBalance
+            val durationMs = curr.sampledAt - prev.sampledAt
+            val durationDays = durationMs.toDouble() / MILLIS_PER_DAY
+
+            when {
+                diff > EPSILON -> {
+                    val consumed = diff
+                    val dailyRate = if (durationDays > 0) consumed / durationDays else 0.0
+                    intervals.add(
+                        ElectricConsumptionInterval(
+                            startAt = prev.sampledAt,
+                            endAt = curr.sampledAt,
+                            startBalance = prev.remainingBalance,
+                            endBalance = curr.remainingBalance,
+                            consumed = consumed,
+                            durationDays = durationDays,
+                            dailyRate = dailyRate
+                        )
+                    )
+                    totalConsumed += consumed
+                    if (durationDays > 0) {
+                        totalDurationDays += durationDays
+                    }
+                    distributeConsumptionByDay(
+                        dailyConsumptionMap = dailyConsumptionMap,
+                        startAt = prev.sampledAt,
+                        endAt = curr.sampledAt,
+                        consumed = consumed
+                    )
+                }
+                diff < -EPSILON -> {
+                    val increaseAmount = curr.remainingBalance - prev.remainingBalance
+                    increases.add(
+                        ElectricIncreaseEvent(
+                            sampledAt = curr.sampledAt,
+                            amount = increaseAmount
+                        )
+                    )
+                }
+                else -> {
+                    // 余额基本不变
+                }
+            }
+        }
+
+        val latestBalance = sorted.lastOrNull()?.remainingBalance
+        val firstSampleAt = sorted.firstOrNull()?.sampledAt
+        val latestSampleAt = sorted.lastOrNull()?.sampledAt
+
+        val averageDailyConsumption = if (totalDurationDays > 0) {
+            totalConsumed / totalDurationDays
+        } else {
+            null
+        }
+
+        val estimatedRemainingDays = if (latestBalance != null &&
+            latestBalance > 0 &&
+            averageDailyConsumption != null &&
+            averageDailyConsumption > 0 &&
+            intervals.isNotEmpty()
+        ) {
+            latestBalance / averageDailyConsumption
+        } else {
+            null
+        }
+
+        return ElectricUsageSummary(
+            latestBalance = latestBalance,
+            firstSampleAt = firstSampleAt,
+            latestSampleAt = latestSampleAt,
+            totalConsumed = totalConsumed,
+            averageDailyConsumption = averageDailyConsumption,
+            estimatedRemainingDays = estimatedRemainingDays,
+            validIntervalCount = intervals.size,
+            increases = increases,
+            intervals = intervals,
+            dailyConsumptions = dailyConsumptionMap
+                .map { (dayStartAt, consumed) ->
+                    ElectricDailyConsumption(
+                        dayStartAt = dayStartAt,
+                        consumed = consumed
+                    )
+                }
+                .filter { it.consumed > EPSILON }
+        )
+    }
+
+    fun calculateRecent7DaysConsumption(
+        records: List<ElectricBalanceRecordEntity>,
+        now: Long = System.currentTimeMillis()
+    ): Double {
+        if (records.isEmpty()) return 0.0
+
+        val meterKeys = records.map { it.meterKey }.distinct()
+        require(meterKeys.size <= 1) {
+            "ElectricUsageCalculator only accepts records from one meterKey, but got: $meterKeys"
+        }
+
+        val sevenDaysAgo = now - 7 * MILLIS_PER_DAY
+        var consumption = 0.0
+
+        val sorted = records.sortedBy { it.sampledAt }
+        for (i in 1 until sorted.size) {
+            val prev = sorted[i - 1]
+            val curr = sorted[i]
+
+            if (curr.sampledAt <= prev.sampledAt) continue
+
+            val diff = prev.remainingBalance - curr.remainingBalance
+            if (diff <= EPSILON) continue
+
+            val intervalStart = prev.sampledAt
+            val intervalEnd = curr.sampledAt
+
+            if (intervalEnd <= sevenDaysAgo) continue
+            if (intervalStart >= now) continue
+
+            val effectiveStart = maxOf(intervalStart, sevenDaysAgo)
+            val effectiveEnd = minOf(intervalEnd, now)
+            val totalDuration = (intervalEnd - intervalStart).toDouble()
+
+            if (totalDuration > 0) {
+                val overlapRatio = (effectiveEnd - effectiveStart).toDouble() / totalDuration
+                consumption += diff * overlapRatio
+            }
+        }
+
+        return consumption
+    }
+
+    private fun distributeConsumptionByDay(
+        dailyConsumptionMap: MutableMap<Long, Double>,
+        startAt: Long,
+        endAt: Long,
+        consumed: Double
+    ) {
+        val totalDuration = endAt - startAt
+        if (totalDuration <= 0L || consumed <= EPSILON) return
+
+        var cursor = startAt
+        while (cursor < endAt) {
+            val dayStart = startOfDay(cursor)
+            val nextDayStart = nextDayStart(cursor)
+            val segmentEnd = minOf(endAt, nextDayStart)
+            val segmentDuration = segmentEnd - cursor
+            if (segmentDuration > 0) {
+                val segmentConsumed = consumed * segmentDuration.toDouble() / totalDuration.toDouble()
+                dailyConsumptionMap[dayStart] = (dailyConsumptionMap[dayStart] ?: 0.0) + segmentConsumed
+            }
+            cursor = segmentEnd
+        }
+    }
+
+    private fun startOfDay(timeMillis: Long): Long {
+        return Calendar.getInstance().apply {
+            timeInMillis = timeMillis
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
+    }
+
+    private fun nextDayStart(timeMillis: Long): Long {
+        return Calendar.getInstance().apply {
+            timeInMillis = startOfDay(timeMillis)
+            add(Calendar.DAY_OF_MONTH, 1)
+        }.timeInMillis
+    }
+
+    private fun emptySummary() = ElectricUsageSummary(
+        latestBalance = null,
+        firstSampleAt = null,
+        latestSampleAt = null,
+        totalConsumed = 0.0,
+        averageDailyConsumption = null,
+        estimatedRemainingDays = null,
+        validIntervalCount = 0,
+        increases = emptyList(),
+        intervals = emptyList(),
+        dailyConsumptions = emptyList()
+    )
+}

--- a/app/src/main/java/com/hfut/schedule/logic/network/exception/ElectricQueryExceptions.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/network/exception/ElectricQueryExceptions.kt
@@ -1,0 +1,16 @@
+package com.hfut.schedule.logic.network.exception
+
+import java.io.IOException
+
+/**
+ * Thrown when the electric fee API returns HTTP 200 but the response body is empty or blank.
+ */
+class EmptyElectricResponseException :
+    IOException("电费接口响应体为空")
+
+/**
+ * Thrown when reading the electric fee API response body fails.
+ */
+class ElectricResponseReadException(
+    cause: Throwable
+) : IOException("读取电费接口响应体失败", cause)

--- a/app/src/main/java/com/hfut/schedule/logic/network/repo/HuiXinRepository.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/network/repo/HuiXinRepository.kt
@@ -34,10 +34,142 @@ import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
 import retrofit2.Call
 import retrofit2.Callback
+import retrofit2.HttpException
 import retrofit2.Response
+import com.hfut.schedule.logic.network.exception.ElectricResponseReadException
+import com.hfut.schedule.logic.network.exception.EmptyElectricResponseException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 object HuiXinRepository {
     private val huiXin = HuiXinServiceCreator.create(HuiXinService::class.java)
+
+    private data class FeeRequestParams(
+        val feeItemId: Int,
+        val campus: String?,
+        val level: String?,
+        val room: String?,
+        val phoneNumber: String?,
+        val building: String?
+    )
+
+    private fun buildFeeParams(
+        type: FeeType,
+        room: String?,
+        phoneNumber: String?,
+        building: String?
+    ): FeeRequestParams {
+        val feeItemId = type.code
+        val campus = when (type) {
+            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> "1sh"
+            else -> null
+        }
+        val levels = when (type) {
+            FeeType.NET_XUANCHENG -> "0"
+            FeeType.ELECTRIC_XUANCHENG -> null
+            FeeType.SHOWER_XUANCHENG -> "1"
+            FeeType.SHOWER_HEFEI -> "未适配"
+            FeeType.WASHING_HEFEI -> "未适配"
+            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> "1"
+        }
+        val rooms = when (type) {
+            FeeType.NET_XUANCHENG -> null
+            FeeType.ELECTRIC_XUANCHENG -> room
+            FeeType.SHOWER_XUANCHENG -> null
+            FeeType.SHOWER_HEFEI -> null
+            FeeType.WASHING_HEFEI -> "未适配"
+            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> room
+        }
+        val phoneNumbers = when (type) {
+            FeeType.NET_XUANCHENG -> null
+            FeeType.ELECTRIC_XUANCHENG -> null
+            FeeType.SHOWER_XUANCHENG -> phoneNumber
+            FeeType.SHOWER_HEFEI -> phoneNumber
+            FeeType.WASHING_HEFEI -> "未适配"
+            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> null
+        }
+        val buildings = when (type) {
+            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> building
+            else -> null
+        }
+        return FeeRequestParams(feeItemId, campus, levels, rooms, phoneNumbers, buildings)
+    }
+
+    /**
+     * Suspend API that returns the raw response body for a single fee query.
+     * Each call creates an independent Retrofit Call, so concurrent requests
+     * cannot interfere with each other.
+     *
+     * @return response body string (non-null, non-blank)
+     * @throws retrofit2.HttpException on HTTP non-2xx responses
+     * @throws java.io.IOException on empty body or body read failure
+     * @throws Exception on network failure
+     */
+    suspend fun queryFeeRaw(
+        auth: String,
+        type: FeeType,
+        room: String? = null,
+        phoneNumber: String? = null,
+        building: String? = null
+    ): String {
+        val params = buildFeeParams(type, room, phoneNumber, building)
+        return kotlinx.coroutines.suspendCancellableCoroutine { continuation ->
+            val call = huiXin.getFee(
+                auth = auth,
+                typeId = params.feeItemId,
+                room = params.room,
+                level = params.level,
+                phoneNumber = params.phoneNumber,
+                type = "IEC",
+                campus = params.campus,
+                building = params.building
+            )
+
+            continuation.invokeOnCancellation {
+                call.cancel()
+            }
+
+            call.enqueue(object : Callback<ResponseBody> {
+                override fun onResponse(
+                    call: Call<ResponseBody>,
+                    response: Response<ResponseBody>
+                ) {
+                    if (!continuation.isActive) return
+
+                    if (!response.isSuccessful) {
+                        continuation.resumeWithException(
+                            HttpException(response)
+                        )
+                        return
+                    }
+
+                    val body = try {
+                        response.body()?.string()
+                    } catch (e: Exception) {
+                        continuation.resumeWithException(
+                            ElectricResponseReadException(e)
+                        )
+                        return
+                    }
+
+                    if (body.isNullOrBlank()) {
+                        continuation.resumeWithException(
+                            EmptyElectricResponseException()
+                        )
+                        return
+                    }
+
+                    continuation.resume(body)
+                }
+
+                override fun onFailure(call: Call<ResponseBody>, t: Throwable) {
+                    if (!continuation.isActive) return
+                    if (call.isCanceled) return
+                    continuation.resumeWithException(t)
+                }
+            })
+        }
+    }
 
     suspend fun getCardBill(
         auth : String,
@@ -295,49 +427,16 @@ object HuiXinRepository {
         electricData : MutableLiveData<String?>,
         showerData : MutableLiveData<String?>
     ) {
-
-        val feeItemId = type.code
-        val campus = when(type) {
-            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> "1sh"
-            else -> null
-        }
-        val levels = when(type) {
-            FeeType.NET_XUANCHENG -> "0"
-            FeeType.ELECTRIC_XUANCHENG -> null
-            FeeType.SHOWER_XUANCHENG -> "1"
-            FeeType.SHOWER_HEFEI -> "未适配"
-            FeeType.WASHING_HEFEI -> "未适配"
-            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> "1"
-        }
-        val rooms = when(type) {
-            FeeType.NET_XUANCHENG -> null
-            FeeType.ELECTRIC_XUANCHENG -> room
-            FeeType.SHOWER_XUANCHENG -> null
-            FeeType.SHOWER_HEFEI -> null
-            FeeType.WASHING_HEFEI -> "未适配"
-            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> room
-        }
-        val phoneNumbers = when(type) {
-            FeeType.NET_XUANCHENG -> null
-            FeeType.ELECTRIC_XUANCHENG -> null
-            FeeType.SHOWER_XUANCHENG -> phoneNumber
-            FeeType.SHOWER_HEFEI -> phoneNumber
-            FeeType.WASHING_HEFEI -> "未适配"
-            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> null
-        }
-        val buildings = when(type) {
-            FeeType.ELECTRIC_HEFEI_UNDERGRADUATE -> building
-            else -> null
-        }
+        val params = buildFeeParams(type, room, phoneNumber, building)
         val call = huiXin.getFee(
             auth = auth,
-            typeId = feeItemId,
-            room = rooms,
-            level = levels,
-            phoneNumber = phoneNumbers,
+            typeId = params.feeItemId,
+            room = params.room,
+            level = params.level,
+            phoneNumber = params.phoneNumber,
             type = "IEC",
-            campus = campus,
-            building = buildings
+            campus = params.campus,
+            building = params.building
         )
 
         call.enqueue(object : Callback<ResponseBody> {

--- a/app/src/main/java/com/hfut/schedule/logic/network/util/ElectricFeeResponseClassifier.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/network/util/ElectricFeeResponseClassifier.kt
@@ -1,0 +1,82 @@
+package com.hfut.schedule.logic.network.util
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.xah.common.logic.util.LogUtil
+
+/**
+ * Classifies electric fee API responses as business success or failure.
+ * Uses Gson for proper JSON parsing instead of fragile regex matching.
+ *
+ * The HuiXin electric fee API returns JSON with a "map" object containing "showData"
+ * on success. Some responses also include a "msg":"success" field or "success":true.
+ */
+object ElectricFeeResponseClassifier {
+
+    /**
+     * Determines if the raw response body represents a successful business response.
+     *
+     * Classification priority:
+     * 1. "success":false → explicit failure (returns false)
+     * 2. "msg":"success" (case insensitive) → success
+     * 3. "success":true → success
+     * 4. "map":{"showData":{...}} exists → success
+     * 5. JSON parse failure → false
+     *
+     * @return true if the response indicates business success, false otherwise
+     */
+    fun isBusinessSuccess(rawBody: String?): Boolean {
+        if (rawBody.isNullOrBlank()) return false
+        return try {
+            val rootElement = JsonParser().parse(rawBody)
+            if (!rootElement.isJsonObject) return false
+            classify(rootElement.asJsonObject)
+        } catch (e: Exception) {
+            LogUtil.error(e, "解析电费业务响应失败")
+            false
+        }
+    }
+
+    private fun classify(root: JsonObject): Boolean {
+        val successElement = root.get("success")
+        val msgElement = root.get("msg")
+
+        // If "success" field exists, it must be a boolean primitive
+        if (successElement != null) {
+            if (!successElement.isJsonPrimitive ||
+                !successElement.asJsonPrimitive.isBoolean
+            ) {
+                // success field has wrong type (number, string, null, etc.) → failure
+                return false
+            }
+            if (!successElement.asBoolean) {
+                return false
+            }
+        }
+
+        // If "msg" field exists, it must be a string primitive
+        if (msgElement != null) {
+            if (!msgElement.isJsonPrimitive ||
+                !msgElement.asJsonPrimitive.isString
+            ) {
+                // msg field has wrong type (number, null, etc.) → failure
+                return false
+            }
+            return msgElement.asString.equals("success", ignoreCase = true)
+        }
+
+        // success:true (already validated as boolean above)
+        if (successElement?.asBoolean == true) {
+            return true
+        }
+
+        // Fallback: check for "map":{"showData":{...}} structure
+        val mapElement = root.get("map")
+        if (mapElement == null || !mapElement.isJsonObject) {
+            return false
+        }
+        val map = mapElement.asJsonObject
+        val showData = map.get("showData")
+        return showData != null && showData.isJsonObject
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/logic/util/storage/kv/DataStoreManager.kt
+++ b/app/src/main/java/com/hfut/schedule/logic/util/storage/kv/DataStoreManager.kt
@@ -82,6 +82,12 @@ object DataStoreManager : IDataStore {
         val roomNumber : String,
         val name : String
     )
+    data class XuanchengElectricStorage(
+        val buildingNumber : String,
+        val roomNumber : String,
+        val endNumber : String,
+        val name : String
+    )
 
     enum class ShowTeacherConfig(override val code : Int,override val label: UiText) : BaseChoice {
         ONLY_MULTI(0,res(R.string.appearance_settings_choice_display_teachers_only_multi)),
@@ -130,6 +136,10 @@ object DataStoreManager : IDataStore {
     private val HEFEI_ELECTRIC = stringPreferencesKey("hefei_electric")
     private val HEFEI_ELECTRIC_FEE = stringPreferencesKey("hefei_electric_fee")
     private val USE_HEFEI_ELECTRIC = booleanPreferencesKey("use_hefei_electric")
+    private val XUANCHENG_ELECTRIC_BUILDING_NUMBER = stringPreferencesKey("xuancheng_electric_building_number")
+    private val XUANCHENG_ELECTRIC_ROOM_NUMBER = stringPreferencesKey("xuancheng_electric_room_number")
+    private val XUANCHENG_ELECTRIC_END_NUMBER = stringPreferencesKey("xuancheng_electric_end_number")
+    private val XUANCHENG_ELECTRIC_NAME = stringPreferencesKey("xuancheng_electric_name")
     private val LIQUID_GLASS = booleanPreferencesKey("liquid_glass")
     private val CAMERA_DYNAMIC_RECORD = booleanPreferencesKey("camera_dynamic_record_2")
     private val USE_DOUBLE_EXTENSION = booleanPreferencesKey("use_double_extension")
@@ -196,6 +206,10 @@ object DataStoreManager : IDataStore {
     private suspend fun saveHefeiBuildingNumber(value: String) = saveValue(HEFEI_BUILDING_NUMBER, value)
     private suspend fun saveHefeiElectricName(value: String) = saveValue(HEFEI_ELECTRIC, value)
     private suspend fun saveHefeiRoomNumber(value: String) = saveValue(HEFEI_ROOM_NUMBER, value)
+    private suspend fun saveXuanchengBuildingNumber(value: String) = saveValue(XUANCHENG_ELECTRIC_BUILDING_NUMBER, value)
+    private suspend fun saveXuanchengRoomNumber(value: String) = saveValue(XUANCHENG_ELECTRIC_ROOM_NUMBER, value)
+    private suspend fun saveXuanchengEndNumber(value: String) = saveValue(XUANCHENG_ELECTRIC_END_NUMBER, value)
+    private suspend fun saveXuanchengElectricName(value: String) = saveValue(XUANCHENG_ELECTRIC_NAME, value)
     suspend fun saveHefeiElectricFee(value: String) = saveValue(HEFEI_ELECTRIC_FEE, value)
     suspend fun saveApiKey(value: String) = saveValue(API_KEY, value)
     suspend fun saveUseHefeiElectric(value: Boolean) = saveValue(USE_HEFEI_ELECTRIC, value)
@@ -218,6 +232,14 @@ object DataStoreManager : IDataStore {
             launch { saveHefeiRoomNumber(roomNumber) }
             launch { saveHefeiBuildingNumber(buildingNumber) }
             launch { saveHefeiElectricName(name) }
+        }
+    }
+    suspend fun saveXuanchengElectric(bean : XuanchengElectricStorage)  = withContext(Dispatchers.IO) {
+        with(bean) {
+            launch { saveXuanchengBuildingNumber(buildingNumber) }
+            launch { saveXuanchengRoomNumber(roomNumber) }
+            launch { saveXuanchengEndNumber(endNumber) }
+            launch { saveXuanchengElectricName(name) }
         }
     }
     suspend fun saveMergeSquare(value: Boolean) = saveValue(MERGE_SQUARE,value)
@@ -295,6 +317,17 @@ object DataStoreManager : IDataStore {
     private val hefeiBuildingNumber = getFlow(HEFEI_BUILDING_NUMBER,EMPTY_STRING)
     private val hefeiRoomNumber = getFlow(HEFEI_ROOM_NUMBER,EMPTY_STRING)
     private val hefeiElectric = getFlow(HEFEI_ELECTRIC,EMPTY_STRING)
+    val xuanchengElectric: Flow<XuanchengElectricStorage?> = dataStore.data.map { preferences ->
+        val buildingNumber = preferences[XUANCHENG_ELECTRIC_BUILDING_NUMBER] ?: EMPTY_STRING
+        val roomNumber = preferences[XUANCHENG_ELECTRIC_ROOM_NUMBER] ?: EMPTY_STRING
+        val endNumber = preferences[XUANCHENG_ELECTRIC_END_NUMBER] ?: EMPTY_STRING
+        val name = preferences[XUANCHENG_ELECTRIC_NAME] ?: EMPTY_STRING
+        if (buildingNumber == EMPTY_STRING || roomNumber == EMPTY_STRING || endNumber == EMPTY_STRING || name == EMPTY_STRING) {
+            null
+        } else {
+            XuanchengElectricStorage(buildingNumber, roomNumber, endNumber, name)
+        }
+    }
     val termStartDate = getFlow(TERM_START_DATE, getDefaultStartTerm())
     suspend fun getHefeiElectric(): HefeiElectricStorage? = withContext(Dispatchers.IO) {
         val hefeiBuildingNumber = hefeiBuildingNumber.first()
@@ -304,6 +337,31 @@ object DataStoreManager : IDataStore {
             return@withContext null
         }
         return@withContext HefeiElectricStorage(hefeiBuildingNumber, hefeiRoomNumber, hefeiElectric)
+    }
+    suspend fun getXuanchengElectric(): XuanchengElectricStorage? = withContext(Dispatchers.IO) {
+        xuanchengElectric.first()
+    }
+
+    suspend fun migrateXuanchengElectricIfNeeded() = withContext(Dispatchers.IO) {
+        if (getXuanchengElectric() != null) return@withContext
+
+        val sp = SharedPrefs.prefs
+        val buildingNumber = sp.getString("BuildNumber", null)
+            ?.takeIf { it.isNotBlank() && it != "0" }
+            ?: return@withContext
+        val roomNumber = sp.getString("RoomNumber", null)
+            ?.takeIf { it.isNotBlank() }
+            ?: return@withContext
+        val endNumber = sp.getString("EndNumber", null)
+            ?.takeIf { it.isNotBlank() }
+            ?: return@withContext
+        val roomName = sp.getString("RoomText", null)
+            ?.takeIf { it.isNotBlank() }
+            ?: "${buildingNumber}号楼${roomNumber}寝室"
+
+        saveXuanchengElectric(
+            XuanchengElectricStorage(buildingNumber, roomNumber, endNumber, roomName)
+        )
     }
     val enableMergeSquare = getFlow(MERGE_SQUARE,false)
 

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/cube/sub/FocusCardSettings.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/cube/sub/FocusCardSettings.kt
@@ -43,11 +43,17 @@ import androidx.compose.ui.unit.dp
 
 import com.hfut.schedule.R
 import com.hfut.schedule.logic.database.DataBaseManager
+import com.hfut.schedule.logic.database.repository.ElectricHistoryRepository
+import com.hfut.schedule.logic.database.util.ElectricBalanceParser
+import com.hfut.schedule.logic.database.util.ElectricMeterKeyFactory
 import com.hfut.schedule.logic.database.util.insertSafely
 import com.hfut.schedule.logic.enumeration.CampusRegion
 import com.hfut.schedule.logic.enumeration.getCampusRegion
 import com.hfut.schedule.logic.model.huixin.FeeResponse
 import com.hfut.schedule.logic.model.huixin.FeeType
+import com.hfut.schedule.logic.network.exception.EmptyElectricResponseException
+import com.hfut.schedule.logic.network.exception.ElectricResponseReadException
+import com.hfut.schedule.logic.network.util.ElectricFeeResponseClassifier
 import com.xah.common.logic.state.NetworkUiState
 
 import com.hfut.schedule.logic.util.parse.roundOffString
@@ -89,13 +95,14 @@ import com.xah.container.component.base.sharedContainer
 import com.xah.navigation.util.LocalNavController
 import com.xah.common.logic.util.LogUtil
 import dev.chrisbanes.haze.HazeState
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -350,58 +357,162 @@ suspend fun getWebInfoFromHuiXin(vm: NetWorkViewModel, vmUI : UIViewModel) = wit
     }
 }
 
-suspend fun getElectricFromHuiXin(vm : NetWorkViewModel, vmUI : UIViewModel) = withContext(Dispatchers.IO) {
-    val useHefei = DataStoreManager.useHefeiElectric.first()
-    val auth = prefs.getString("auth","")
-    if(useHefei) {
-        val bean = DataStoreManager.getHefeiElectric()
-        if(bean == null) {
-            vmUI.electricValue.value = "--"
-            saveString("memoryEle","0.0")
-            return@withContext
-        }
-        async { vm.getFee("bearer $auth", FeeType.ELECTRIC_HEFEI_UNDERGRADUATE, room = bean.roomNumber, building = bean.buildingNumber) }.await()
-        async {
-            Handler(Looper.getMainLooper()).post{
-                vm.hefeiElectric.observeForever { result ->
-                    if (result?.contains("success") == true) {
-                        try {
-                            val data = GsonInstance.fromJson(result,FeeResponse::class.java).map.showData
-                            for ((_, value) in data) {
+suspend fun getElectricFromHuiXin(vm : NetWorkViewModel, vmUI : UIViewModel) {
+    try {
+        val useHefei = DataStoreManager.useHefeiElectric.first()
+        val auth = prefs.getString("auth","")
+        if(useHefei) {
+            val bean = DataStoreManager.getHefeiElectric()
+            if(bean == null) {
+                withContext(Dispatchers.Main.immediate) {
+                    vmUI.electricValue.value = "--"
+                }
+                saveString("memoryEle","0.0")
+                return
+            }
+            val queryBuildingNumber = bean.buildingNumber
+            val queryRoomNumber = bean.roomNumber
+            val queryRoomName = bean.name
+            if (queryBuildingNumber.isBlank() || queryRoomNumber.isBlank() || queryRoomName.isBlank()) {
+                LogUtil.error("自动电费查询：合肥寝室配置不完整")
+                return
+            }
+            try {
+                val result = withTimeoutOrNull(15_000L.milliseconds) {
+                    vm.queryElectricFee(
+                        auth = "bearer $auth",
+                        type = FeeType.ELECTRIC_HEFEI_UNDERGRADUATE,
+                        room = queryRoomNumber,
+                        building = queryBuildingNumber
+                    )
+                }
+                if (result == null) {
+                    LogUtil.error("自动电费查询超时")
+                    return
+                }
+                if (!ElectricFeeResponseClassifier.isBusinessSuccess(result)) {
+                    LogUtil.error("自动电费查询业务失败")
+                    return
+                }
+                try {
+                        val data = GsonInstance.fromJson(result,FeeResponse::class.java).map.showData
+                        if (data.isEmpty()) {
+                            LogUtil.error("自动电费查询未返回余额数据")
+                            return
+                        }
+                        var hasValidBalance = false
+                        for ((_, value) in data) {
+                            val balance = ElectricBalanceParser.parseHefeiBalance(value)
+                            if (balance == null) {
+                                LogUtil.error("自动电费查询：合肥余额解析失败")
+                                continue
+                            }
+                            hasValidBalance = true
+                            withContext(Dispatchers.Main.immediate) {
                                 vmUI.electricValue.value = value
-                                saveString("memoryEle",vmUI.electricValue.value)
                             }
-                        } catch (e:Exception) {
-                            LogUtil.error(e)
+                            DataStoreManager.saveHefeiElectricFee(value)
+                            saveString("memoryEle",value)
+                            val meterKey = ElectricMeterKeyFactory.hefei(queryBuildingNumber, queryRoomNumber)
+                            ElectricHistoryRepository.recordSnapshot(
+                                meterKey = meterKey,
+                                campusRegion = CampusRegion.HEFEI.description,
+                                roomName = queryRoomName,
+                                balance = balance
+                            )
                         }
+                        if (!hasValidBalance) {
+                            LogUtil.error("自动电费查询：合肥所有余额均解析失败")
+                        }
+                    } catch (e:Exception) {
+                        if (e is CancellationException) throw e
+                        LogUtil.error(e)
                     }
-                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: EmptyElectricResponseException) {
+                LogUtil.error(e, "自动电费查询：服务器未返回数据")
+            } catch (e: ElectricResponseReadException) {
+                LogUtil.error(e, "自动电费查询：响应读取失败")
+            } catch (e: Exception) {
+                LogUtil.error(e)
             }
-        }
-    } else {
-        val BuildingsNumber = prefs.getString("BuildNumber", "0")
-        val RoomNumber = prefs.getString("RoomNumber", "")
-        val EndNumber = prefs.getString("EndNumber", "")
+        } else {
+            DataStoreManager.migrateXuanchengElectricIfNeeded()
+            val bean = DataStoreManager.getXuanchengElectric()
+            if (bean == null) {
+                withContext(Dispatchers.Main.immediate) {
+                    vmUI.electricValue.value = "--"
+                }
+                saveString("memoryEle","0.0")
+                return
+            }
 
-        var input = "300$BuildingsNumber$RoomNumber$EndNumber"
-        async { vm.getFee("bearer $auth", FeeType.ELECTRIC_XUANCHENG, room = input) }.await()
-        async {
-            Handler(Looper.getMainLooper()).post{
-                vm.electricData.observeForever { result ->
-                    if (result?.contains("success") == true) {
-                        try {
-                            val data = GsonInstance.fromJson(result,FeeResponse::class.java).map.showData
-                            for ((_, value) in data) {
-                                vmUI.electricValue.value = value.substringAfter("剩余金额:").toDouble().roundOffString(2)
-                                saveString("memoryEle",vmUI.electricValue.value)
-                            }
-                        } catch (e:Exception) {
-                            LogUtil.error(e)
-                        }
-                    }
+            val input = "300${bean.buildingNumber}${bean.roomNumber}${bean.endNumber}"
+            try {
+                val result = withTimeoutOrNull(15_000L.milliseconds) {
+                    vm.queryElectricFee(
+                        auth = "bearer $auth",
+                        type = FeeType.ELECTRIC_XUANCHENG,
+                        room = input
+                    )
                 }
+                if (result == null) {
+                    LogUtil.error("自动电费查询超时")
+                    return
+                }
+                if (!ElectricFeeResponseClassifier.isBusinessSuccess(result)) {
+                    LogUtil.error("自动电费查询业务失败")
+                    return
+                }
+                try {
+                    val data = GsonInstance.fromJson(result,FeeResponse::class.java).map.showData
+                    if (data.isEmpty()) {
+                        LogUtil.error("自动电费查询未返回余额数据")
+                        return
+                    }
+                    var hasValidBalance = false
+                    for ((_, value) in data) {
+                        val balance = ElectricBalanceParser.parseXuanchengBalance(value)
+                        if (balance == null) {
+                            LogUtil.error("自动电费查询：宣城余额解析失败")
+                            continue
+                        }
+                        hasValidBalance = true
+                        val parsedFee = balance.roundOffString(2)
+                        withContext(Dispatchers.Main.immediate) {
+                            vmUI.electricValue.value = parsedFee
+                        }
+                        saveString("memoryEle",parsedFee)
+                        val meterKey = ElectricMeterKeyFactory.xuancheng(input)
+                        ElectricHistoryRepository.recordSnapshot(
+                            meterKey = meterKey,
+                            campusRegion = CampusRegion.XUANCHENG.description,
+                            roomName = bean.name,
+                            balance = balance
+                        )
+                    }
+                    if (!hasValidBalance) {
+                        LogUtil.error("自动电费查询：宣城所有余额均解析失败")
+                    }
+                } catch (e:Exception) {
+                    if (e is CancellationException) throw e
+                    LogUtil.error(e)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: EmptyElectricResponseException) {
+                LogUtil.error(e, "自动电费查询：服务器未返回数据")
+            } catch (e: ElectricResponseReadException) {
+                LogUtil.error(e, "自动电费查询：响应读取失败")
+            } catch (e: Exception) {
+                LogUtil.error(e)
             }
         }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        LogUtil.error(e, "自动电费查询初始化失败")
     }
 }
 
@@ -572,4 +683,3 @@ fun ChangeCourseUI(
         }
     }
 }
-

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/Electric.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/Electric.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.hfut.schedule.ui.screen.home.search.function.huiXin.electric
 
 import android.annotation.SuppressLint
@@ -7,6 +9,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -14,60 +18,83 @@ import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.Observer
 import com.hfut.schedule.R
 import com.hfut.schedule.logic.enumeration.CampusRegion
 import com.hfut.schedule.logic.enumeration.getCampusRegion
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager.HefeiElectricStorage
-import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
+import com.xah.common.logic.util.LogUtil
 import com.xah.common.ui.component.text.ScrollText
 import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.style.special.HazeBottomSheet
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
 import com.hfut.schedule.viewmodel.ui.UIViewModel
 import dev.chrisbanes.haze.HazeState
+import kotlinx.coroutines.CancellationException
+
+private fun xuanchengElectricRegion(buildingNumber: String, endNumber: String): String? {
+    val building = buildingNumber.toIntOrNull() ?: return null
+    return when(endNumber) {
+        "11" -> if(building > 5) "照明" else "南边"
+        "12" -> "空调"
+        "21" -> if(building > 5) "照明" else "北边"
+        "22" -> "空调"
+        else -> null
+    }
+}
 
 @SuppressLint("SuspiciousIndentation")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Electric(vm : NetWorkViewModel, card : Boolean, vmUI : UIViewModel, hazeState: HazeState) {
-    val context = LocalContext.current
+    val defaultRoomText = stringResource(R.string.navigation_label_dormitory_electricity_bill)
     val useHefei by DataStoreManager.useHefeiElectric.collectAsState(initial = getCampusRegion() == CampusRegion.HEFEI)
-    var room by remember { mutableStateOf(context.getString(R.string.navigation_label_dormitory_electricity_bill)) }
+
+    LaunchedEffect(Unit) {
+        try {
+            DataStoreManager.migrateXuanchengElectricIfNeeded()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LogUtil.error(e, "迁移宣城电费配置失败")
+        }
+    }
 
     var showBottomSheet by remember { mutableStateOf(false) }
-    if(useHefei) {
+    val room = if(useHefei) {
         val name by produceState<HefeiElectricStorage?>(initialValue = null) {
             value = DataStoreManager.getHefeiElectric()
         }
-        room = name?.name ?: "合肥"
+        name?.name ?: "合肥"
     } else {
-        val buildingNumber = prefs.getString("BuildNumber", "0") ?: "0"
-
-        room = when( prefs.getString("EndNumber", "0")) {
-            "11"-> if(buildingNumber.toInt() > 5 )"照明" else "南边"
-            "12" -> "空调"
-            "21" -> if(buildingNumber.toInt() > 5 )"照明" else "北边"
-            "22" -> "空调"
-            else -> stringResource(R.string.navigation_label_dormitory_electricity_bill)
-        }
+        val xuanchengElectric by DataStoreManager.xuanchengElectric.collectAsState(initial = null)
+        xuanchengElectric?.let { xuanchengElectricRegion(it.buildingNumber, it.endNumber) }
+            ?: defaultRoomText
     }
 
 
     if (showBottomSheet) {
         HazeBottomSheet(
             onDismissRequest = { showBottomSheet = false },
-            showBottomSheet = showBottomSheet
+            showBottomSheet = true,
+            sheetGesturesEnabled = false
         ) {
             EleUI(vm = vm,hazeState)
         }
     }
 
-    val f = vmUI.electricValue.value ?: prefs.getString("memoryEle","0")
-    val fD = f?.toDoubleOrNull() ?: 0.0
+    var electricValue by remember { mutableStateOf(vmUI.electricValue.value) }
+    DisposableEffect(vmUI) {
+        val observer = Observer<String?> { electricValue = it }
+        vmUI.electricValue.observeForever(observer)
+        onDispose { vmUI.electricValue.removeObserver(observer) }
+    }
+    val savedHefeiElectricFee by DataStoreManager.hefeiElectricFee.collectAsState(initial = "0")
+    val f = electricValue ?: savedHefeiElectricFee
+    val fD = f.toDoubleOrNull() ?: 0.0
     val showRed = if(fD < 0.0) {
         // 爆红
         true

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/ElectricHistorySection.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/ElectricHistorySection.kt
@@ -1,0 +1,477 @@
+package com.hfut.schedule.ui.screen.home.search.function.huiXin.electric
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.hfut.schedule.R
+import com.hfut.schedule.logic.util.parse.roundOffString
+import com.hfut.schedule.ui.component.container.CustomCard
+import com.hfut.schedule.ui.component.container.TransplantListItem
+import com.hfut.schedule.ui.component.container.cardNormalColor
+import com.hfut.schedule.ui.component.screen.pager.PaddingForPageControllerButton
+import com.hfut.schedule.ui.component.screen.pager.PageController
+import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
+import com.hfut.schedule.viewmodel.ui.ElectricChartMode
+import com.hfut.schedule.viewmodel.ui.ElectricHistoryRange
+import com.hfut.schedule.viewmodel.ui.ElectricHistoryUiState
+import com.hfut.schedule.viewmodel.ui.ElectricHistoryViewModel
+import com.xah.common.ui.component.chart.LineChart
+import com.xah.common.ui.component.text.BottomTip
+import com.xah.common.ui.style.APP_HORIZONTAL_DP
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+@Composable
+fun ElectricHistorySection(
+    meterKey: String?,
+    roomName: String,
+    viewModel: ElectricHistoryViewModel,
+    onOpenRecords: () -> Unit
+) {
+    LaunchedEffect(meterKey, roomName) {
+        viewModel.setMeterKey(meterKey, roomName)
+    }
+
+    val uiState by viewModel.uiState.collectAsState()
+
+    DividerTextExpandedWith(text = "消费趋势", defaultIsExpanded = false, openBlurAnimation = false) {
+        if (meterKey == null) {
+            return@DividerTextExpandedWith
+        }
+
+        // 时间范围选择 - 始终显示
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = APP_HORIZONTAL_DP),
+            horizontalArrangement = Arrangement.Start
+        ) {
+            FilterChip(
+                selected = uiState.range == ElectricHistoryRange.SEVEN_DAYS,
+                onClick = { viewModel.setRange(ElectricHistoryRange.SEVEN_DAYS) },
+                label = { Text("7天") }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            FilterChip(
+                selected = uiState.range == ElectricHistoryRange.THIRTY_DAYS,
+                onClick = { viewModel.setRange(ElectricHistoryRange.THIRTY_DAYS) },
+                label = { Text("30天") }
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            FilterChip(
+                selected = uiState.range == ElectricHistoryRange.ALL,
+                onClick = { viewModel.setRange(ElectricHistoryRange.ALL) },
+                label = { Text("全部") }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // 根据数据显示不同内容
+        when {
+            uiState.totalRecordCount == 0 -> {
+                // 从未保存过历史
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        headlineContent = { Text("暂无历史数据") },
+                        supportingContent = {
+                            Text("App 会在冷启动、刷新首页或手动查询电费成功后记录余额。消费趋势需要积累至少两次有效查询结果。")
+                        },
+                        leadingContent = { Icon(painterResource(R.drawable.info), null) }
+                    )
+                }
+            }
+            uiState.filteredRecords.size < 2 -> {
+                // 当前范围数据不足，但有历史数据
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        headlineContent = { Text("当前时间范围内暂无足够数据") },
+                        supportingContent = {
+                            Text("请尝试切换到\"30天\"或\"全部\"查看。共 ${uiState.totalRecordCount} 条历史记录。")
+                        },
+                        leadingContent = { Icon(painterResource(R.drawable.info), null) }
+                    )
+                }
+            }
+            else -> {
+                // 数据充足，显示图表和摘要
+
+                // 图表模式选择
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = APP_HORIZONTAL_DP),
+                    horizontalArrangement = Arrangement.Start
+                ) {
+                    FilterChip(
+                        selected = uiState.chartMode == ElectricChartMode.BALANCE,
+                        onClick = { viewModel.setChartMode(ElectricChartMode.BALANCE) },
+                        label = { Text("余额趋势") }
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    FilterChip(
+                        selected = uiState.chartMode == ElectricChartMode.CONSUMPTION_RATE,
+                        onClick = { viewModel.setChartMode(ElectricChartMode.CONSUMPTION_RATE) },
+                        label = { Text("每日消费") }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 图表
+                when (uiState.chartMode) {
+                    ElectricChartMode.BALANCE -> BalanceChart(uiState)
+                    ElectricChartMode.CONSUMPTION_RATE -> ConsumptionRateChart(uiState)
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 摘要信息
+                SummaryCard(uiState, roomName)
+            }
+        }
+
+        if (uiState.totalRecordCount > 0) {
+            Spacer(modifier = Modifier.height(8.dp))
+            BalanceRecordEntry(uiState, onOpenRecords)
+        }
+
+        // 清除历史 - 只要当前电表有记录就显示
+        if (uiState.totalRecordCount > 0) {
+            Spacer(modifier = Modifier.height(8.dp))
+            var showClearDialog by remember { mutableStateOf(false) }
+            CustomCard(color = cardNormalColor()) {
+                TransplantListItem(
+                    headlineContent = { Text("清除当前电表历史") },
+                    supportingContent = { Text("仅删除本机保存的余额记录") },
+                    leadingContent = { Icon(painterResource(R.drawable.delete), null) }
+                )
+                FilledTonalButton(
+                    onClick = { showClearDialog = true },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = APP_HORIZONTAL_DP, vertical = 8.dp)
+                ) {
+                    Text("清除历史")
+                }
+            }
+
+            if (showClearDialog) {
+                AlertDialog(
+                    onDismissRequest = { showClearDialog = false },
+                    title = { Text("清除电费历史") },
+                    text = {
+                        Text("将删除当前寝室电表保存在本机的所有余额记录。该操作不会影响学校账户余额，也不会清除寝室配置。")
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.clearHistory()
+                            showClearDialog = false
+                        }) {
+                            Text("确认清除")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showClearDialog = false }) {
+                            Text("取消")
+                        }
+                    }
+                )
+            }
+        }
+
+        BottomTip("余额数据仅保存在本机，根据两次查询之间的余额变化估算，不代表每天的实际精确用电")
+    }
+}
+
+@Composable
+private fun BalanceRecordEntry(
+    uiState: ElectricHistoryUiState,
+    onOpenRecords: () -> Unit
+) {
+    CustomCard(color = cardNormalColor()) {
+        TransplantListItem(
+            headlineContent = { Text("余额记录") },
+            supportingContent = { Text("共 ${uiState.totalRecordCount} 条，点击分页查看") },
+            leadingContent = { Icon(painterResource(R.drawable.receipt_long), null) }
+        )
+        FilledTonalButton(
+            onClick = onOpenRecords,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = APP_HORIZONTAL_DP, vertical = 8.dp)
+        ) {
+            Text("查看记录")
+        }
+    }
+}
+
+@Composable
+fun ElectricBalanceRecordPage(
+    viewModel: ElectricHistoryViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val dateFormat = remember { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
+    val records = remember(uiState.allRecords) {
+        uiState.allRecords.sortedByDescending { it.sampledAt }
+    }
+    val pageSize = 8
+    val totalPage = ((records.size + pageSize - 1) / pageSize).coerceAtLeast(1)
+    var page by remember(records.size) { mutableIntStateOf(1) }
+    val listState = rememberLazyListState()
+    val pageRecords = remember(records, page) {
+        records.drop((page - 1) * pageSize).take(pageSize)
+    }
+
+    LaunchedEffect(page, totalPage) {
+        if (page > totalPage) page = totalPage
+    }
+
+    Box {
+        LazyColumn(state = listState) {
+            item {
+                CustomCard(color = cardNormalColor()) {
+                    TransplantListItem(
+                        headlineContent = { Text("${records.size} 条余额记录") },
+                        supportingContent = { Text("每页 $pageSize 条，仅显示本机去重后的记录") },
+                        leadingContent = { Icon(painterResource(R.drawable.receipt_long), null) }
+                    )
+                }
+            }
+            if (pageRecords.isEmpty()) {
+                item {
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            headlineContent = { Text("暂无余额记录") },
+                            supportingContent = { Text("查询电费成功后会自动记录余额") },
+                            leadingContent = { Icon(painterResource(R.drawable.info), null) }
+                        )
+                    }
+                }
+            } else {
+                items(pageRecords.size, key = { pageRecords[it].id }) { index ->
+                    val record = pageRecords[index]
+                    CustomCard(color = cardNormalColor()) {
+                        TransplantListItem(
+                            overlineContent = { Text(dateFormat.format(Date(record.sampledAt))) },
+                            headlineContent = {
+                                Text(
+                                    "￥${record.remainingBalance.roundOffString(2)}",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                            },
+                            supportingContent = { Text(record.roomName) },
+                            leadingContent = { Icon(painterResource(R.drawable.flash_on), null) }
+                        )
+                    }
+                }
+            }
+            item { PaddingForPageControllerButton() }
+        }
+        PageController(
+            listState = listState,
+            currentPage = page,
+            onNextPage = { page = it },
+            onPreviousPage = { page = it },
+            range = 1 to totalPage,
+            text = "第${page}/${totalPage}页"
+        )
+    }
+}
+
+@Composable
+private fun BalanceChart(uiState: ElectricHistoryUiState) {
+    val dateFormat = remember { SimpleDateFormat("MM/dd HH:mm", Locale.getDefault()) }
+
+    val chartData = remember(uiState.filteredRecords, dateFormat) {
+        if (uiState.filteredRecords.isEmpty()) return@remember emptyMap()
+
+        val records = uiState.filteredRecords.sortedBy { it.sampledAt }
+        val result = linkedMapOf<String, Float>()
+
+        for (record in records) {
+            result[dateFormat.format(Date(record.sampledAt))] = record.remainingBalance.toFloat()
+        }
+        result
+    }
+
+    if (chartData.isNotEmpty()) {
+        CustomCard(color = cardNormalColor()) {
+            LineChart(
+                data = chartData,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .padding(horizontal = APP_HORIZONTAL_DP),
+                showLabel = true,
+                title = "余额趋势 (元)",
+                yAxisFormatter = { "￥${it.roundOffString(2)}" },
+                xLabelSpacing = if (chartData.size > 3) chartData.size / 3 else 1
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConsumptionRateChart(uiState: ElectricHistoryUiState) {
+    val summary = uiState.summary ?: return
+    val dateFormat = remember { SimpleDateFormat("MM/dd", Locale.getDefault()) }
+
+    val chartData = remember(summary.dailyConsumptions, dateFormat) {
+        if (summary.dailyConsumptions.isEmpty()) return@remember emptyMap()
+
+        val result = linkedMapOf<String, Float>()
+        for (item in summary.dailyConsumptions) {
+            if (item.consumed > 0) {
+                result[dateFormat.format(Date(item.dayStartAt))] = item.consumed.toFloat()
+            }
+        }
+        result
+    }
+
+    if (chartData.isNotEmpty()) {
+        CustomCard(color = cardNormalColor()) {
+            LineChart(
+                data = chartData,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(240.dp)
+                    .padding(horizontal = APP_HORIZONTAL_DP),
+                showLabel = true,
+                title = "每日估算消费 (元)",
+                yAxisFormatter = { "￥${it.roundOffString(2)}" },
+                xLabelSpacing = if (chartData.size > 3) chartData.size / 3 else 1
+            )
+        }
+        BottomTip("按自然日汇总两次查询之间的余额变化，跨天区间会按时间比例分摊")
+    } else {
+        CustomCard(color = cardNormalColor()) {
+            TransplantListItem(
+                headlineContent = { Text("暂无有效每日消费") },
+                supportingContent = { Text("需要至少两次余额下降的记录才能估算每日消费") },
+                leadingContent = { Icon(painterResource(R.drawable.info), null) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun SummaryCard(uiState: ElectricHistoryUiState, roomName: String) {
+    val summary = uiState.summary ?: return
+    val dateFormat = remember { SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault()) }
+
+    CustomCard(color = cardNormalColor()) {
+        TransplantListItem(
+            overlineContent = { Text("当前余额") },
+            headlineContent = {
+                val balance = summary.latestBalance ?: 0.0
+                val balanceText = if (balance < 0) {
+                    "￥${balance.roundOffString(2)} (余额不足)"
+                } else {
+                    "￥${balance.roundOffString(2)}"
+                }
+                Text(
+                    balanceText,
+                    style = MaterialTheme.typography.headlineMedium
+                )
+            }
+        )
+
+        AnimatedVisibility(visible = summary.firstSampleAt != null) {
+            TransplantListItem(
+                overlineContent = { Text("首次记录") },
+                headlineContent = {
+                    Text(summary.firstSampleAt?.let { dateFormat.format(Date(it)) } ?: "--")
+                }
+            )
+        }
+
+        AnimatedVisibility(visible = summary.latestSampleAt != null) {
+            TransplantListItem(
+                overlineContent = { Text("最近记录") },
+                headlineContent = {
+                    Text(summary.latestSampleAt?.let { dateFormat.format(Date(it)) } ?: "--")
+                }
+            )
+        }
+
+        if (summary.firstSampleAt != null && summary.latestSampleAt != null) {
+            val days = (summary.latestSampleAt - summary.firstSampleAt) / (24 * 60 * 60 * 1000.0)
+            TransplantListItem(
+                overlineContent = { Text("已记录天数") },
+                headlineContent = { Text("${days.roundOffString(1)} 天") }
+            )
+        }
+
+        TransplantListItem(
+            overlineContent = { Text("有效消费区间") },
+            headlineContent = { Text("${summary.validIntervalCount} 个") }
+        )
+
+        if (uiState.recent7DaysConsumption > 0) {
+            TransplantListItem(
+                overlineContent = { Text("最近7天估算消费") },
+                headlineContent = { Text("￥${uiState.recent7DaysConsumption.roundOffString(2)}") }
+            )
+        }
+
+        AnimatedVisibility(visible = summary.averageDailyConsumption != null) {
+            TransplantListItem(
+                overlineContent = { Text("平均每天估算消费") },
+                headlineContent = {
+                    Text("￥${(summary.averageDailyConsumption ?: 0.0).roundOffString(2)}")
+                }
+            )
+        }
+
+        AnimatedVisibility(visible = summary.estimatedRemainingDays != null) {
+            TransplantListItem(
+                overlineContent = { Text("预计可使用天数") },
+                headlineContent = {
+                    Text("${(summary.estimatedRemainingDays ?: 0.0).roundOffString(1)} 天")
+                }
+            )
+        }
+
+        if (summary.increases.isNotEmpty()) {
+            val lastIncrease = summary.increases.last()
+            TransplantListItem(
+                overlineContent = { Text("最近一次余额增加") },
+                headlineContent = {
+                    Text(
+                        "￥${lastIncrease.amount.roundOffString(2)} (${
+                            dateFormat.format(Date(lastIncrease.sampledAt))
+                        })"
+                    )
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/ElectricUI.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/screen/home/search/function/huiXin/electric/ElectricUI.kt
@@ -1,9 +1,8 @@
+@file:Suppress("DEPRECATION")
+
 package com.hfut.schedule.ui.screen.home.search.function.huiXin.electric
 
-
 import android.annotation.SuppressLint
-import android.os.Handler
-import android.os.Looper
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandIn
@@ -44,6 +43,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -57,9 +57,13 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 import com.hfut.schedule.R
 import com.hfut.schedule.application.MyApplication
+import com.hfut.schedule.logic.database.repository.ElectricHistoryRepository
+import com.hfut.schedule.logic.database.util.ElectricBalanceParser
+import com.hfut.schedule.logic.database.util.ElectricMeterKeyFactory
 import com.hfut.schedule.logic.enumeration.Campus
 import com.hfut.schedule.logic.enumeration.CampusRegion
 import com.hfut.schedule.logic.enumeration.getCampus
@@ -67,14 +71,15 @@ import com.hfut.schedule.logic.enumeration.getCampusRegion
 import com.hfut.schedule.logic.model.HuiXinHefeiBuildingBean
 import com.hfut.schedule.logic.model.huixin.FeeResponse
 import com.hfut.schedule.logic.model.huixin.FeeType
+import com.hfut.schedule.logic.network.exception.EmptyElectricResponseException
+import com.hfut.schedule.logic.network.exception.ElectricResponseReadException
+import com.hfut.schedule.logic.network.util.ElectricFeeResponseClassifier
 import com.xah.common.logic.state.NetworkUiState
-import com.hfut.schedule.logic.util.network.state.reEmptyLiveDta
 
 import com.hfut.schedule.logic.util.parse.roundOffString
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager.HefeiElectricStorage
 import com.hfut.schedule.logic.util.storage.kv.DataStoreManager.getHefeiElectric
-import com.hfut.schedule.logic.util.storage.kv.SharedPrefs
 import com.hfut.schedule.logic.util.storage.kv.SharedPrefs.prefs
 import com.hfut.schedule.logic.util.sys.Starter
 import com.hfut.schedule.logic.util.sys.showToast
@@ -85,6 +90,7 @@ import com.hfut.schedule.ui.component.button.BottomButton
 import com.hfut.schedule.ui.component.container.CARD_NORMAL_DP
 import com.hfut.schedule.ui.component.container.CustomCard
 import com.hfut.schedule.ui.component.container.LoadingLargeCard
+import com.hfut.schedule.ui.component.container.ShareTwoContainer2D
 import com.hfut.schedule.ui.component.container.TransplantListItem
 import com.hfut.schedule.ui.component.container.cardNormalColor
 import com.hfut.schedule.ui.component.dialog.MenuChip
@@ -95,16 +101,22 @@ import com.hfut.schedule.ui.component.text.DividerTextExpandedWith
 import com.hfut.schedule.ui.component.text.HazeBottomSheetTopBar
 import com.hfut.schedule.ui.style.special.HazeBottomSheet
 import com.hfut.schedule.viewmodel.network.NetWorkViewModel
+import com.hfut.schedule.viewmodel.ui.ElectricHistoryViewModel
 import com.xah.common.ui.component.text.BottomTip
 import com.xah.common.ui.style.APP_HORIZONTAL_DP
 import com.xah.common.logic.util.LogUtil
 import dev.chrisbanes.haze.HazeState
-import kotlinx.coroutines.async
+import retrofit2.HttpException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
+import kotlin.time.Duration.Companion.milliseconds
 
 private const val HEFEI_TAB = 0
 private const val XUANCHENG_TAB = 1
+private const val ELECTRIC_QUERY_TIMEOUT_MS = 15_000L
 
 
 private fun getUrl(page : Int) : String {
@@ -132,32 +144,38 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
     )
     val auth = prefs.getString("auth","")
 
-    val SavedBuildNumber = prefs.getString("BuildNumber", "0") ?: "0"
-    var BuildingsNumber by remember { mutableStateOf(SavedBuildNumber) }
-    val SavedRoomNumber = prefs.getString("RoomNumber", "")
-    var RoomNumber by remember { mutableStateOf(SavedRoomNumber ?: "") }
-    val SavedEndNumber = prefs.getString("EndNumber", "")
-    var EndNumber by remember { mutableStateOf(SavedEndNumber ?: "") }
+    var buildingsNumber by remember { mutableStateOf("") }
+    var roomNumber by remember { mutableStateOf("") }
+    var endNumber by remember { mutableStateOf("") }
+    var restoredXuanchengElectric by remember { mutableStateOf(false) }
 
     var region by remember { mutableStateOf("选择南北") }
-
-    var input = "300$BuildingsNumber$RoomNumber$EndNumber"
 
     var showitem by remember { mutableStateOf(false) }
     var showitem2 by remember { mutableStateOf(false) }
     var showitem3 by remember { mutableStateOf(false) }
     var showitem4 by remember { mutableStateOf(false) }
 
-    var Result by remember { mutableStateOf("") }
-    var Result2 by remember { mutableStateOf("") }
+    // Xuancheng display state — all set in coroutine, never in Composition
+    var xuanchengRoomCodeText by remember { mutableStateOf("") }
+    var xuanchengBalanceText by remember { mutableStateOf("") }
+    var xuanchengResultVisible by remember { mutableStateOf(false) }
+    var xuanchengQueryLoading by remember { mutableStateOf(false) }
 
     var showAdd by remember { mutableStateOf(false) }
     var payNumber by remember { mutableStateOf("") }
     var showBottomSheet by remember { mutableStateOf(false) }
 
-    var show by remember { mutableStateOf(false) }
-
     var json by remember { mutableStateOf("") }
+
+    // Xuancheng success context
+    var queriedMeterKey by remember { mutableStateOf<String?>(null) }
+    var queriedRoomName by remember { mutableStateOf("") }
+
+    // Query jobs for cancellation on rapid re-click
+    var xuanchengQueryJob by remember { mutableStateOf<Job?>(null) }
+    var xuanchengRequestId by remember { mutableLongStateOf(0L) }
+
     if (showBottomSheet) {
 
         HazeBottomSheet (
@@ -168,7 +186,7 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
 
                 ) {
                     HazeBottomSheetTopBar("支付订单确认", isPaddingStatusBar = false)
-                    val roomInfo by remember { mutableStateOf("${BuildingsNumber}号楼${RoomNumber}寝室${region}") }
+                    val roomInfo by remember { mutableStateOf("${buildingsNumber}号楼${roomNumber}寝室${region}") }
                     val int by remember { mutableStateOf(payNumber.toFloat()) }
                     if(int > 0) {
                         PayFor(vm,int,roomInfo,json,FeeType.ELECTRIC_XUANCHENG,hazeState)
@@ -177,12 +195,31 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
         }
     }
 
-    region = when(EndNumber) {
-        "11"-> if(BuildingsNumber.toInt() > 5 )"南边照明" else "南边"
+    region = when(endNumber) {
+        "11"-> if(buildingsNumber.toIntOrNull() ?: 0 > 5 )"南边照明" else "南边"
         "12" -> "南边空调"
-        "21" -> if(BuildingsNumber.toInt() > 5 )"北边照明" else "北边"
+        "21" -> if(buildingsNumber.toIntOrNull() ?: 0 > 5 )"北边照明" else "北边"
         "22" -> "北边空调"
         else -> "选择南北"
+    }
+    LaunchedEffect(Unit) {
+        try {
+            DataStoreManager.migrateXuanchengElectricIfNeeded()
+
+            val saved = DataStoreManager.getXuanchengElectric() ?: return@LaunchedEffect
+            buildingsNumber = saved.buildingNumber
+            roomNumber = saved.roomNumber
+            endNumber = saved.endNumber
+            queriedMeterKey = ElectricMeterKeyFactory.xuancheng(
+                "300${saved.buildingNumber}${saved.roomNumber}${saved.endNumber}"
+            )
+            queriedRoomName = saved.name
+            restoredXuanchengElectric = true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LogUtil.error(e, "恢复宣城电费配置失败")
+        }
     }
 
     var showDialog2 by remember { mutableStateOf(false) }
@@ -284,89 +321,340 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
 
     menuOffset?.let {
         DropdownMenu(expanded = showitem, onDismissRequest = { showitem = false }, offset = it) {
-            DropdownMenuItem(text = { Text(text = "北一号楼") }, onClick = { BuildingsNumber =  "1"
+            DropdownMenuItem(text = { Text(text = "北一号楼") }, onClick = { buildingsNumber =  "1"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "北二号楼") }, onClick = {  BuildingsNumber =  "2"
+            DropdownMenuItem(text = { Text(text = "北二号楼") }, onClick = {  buildingsNumber =  "2"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "北三号楼") }, onClick = {  BuildingsNumber =  "3"
+            DropdownMenuItem(text = { Text(text = "北三号楼") }, onClick = {  buildingsNumber =  "3"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "北四号楼") }, onClick = {  BuildingsNumber =  "4"
+            DropdownMenuItem(text = { Text(text = "北四号楼") }, onClick = {  buildingsNumber =  "4"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "北五号楼") }, onClick = {  BuildingsNumber =  "5"
+            DropdownMenuItem(text = { Text(text = "北五号楼") }, onClick = {  buildingsNumber =  "5"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "南六号楼") }, onClick = {  BuildingsNumber =  "6"
+            DropdownMenuItem(text = { Text(text = "南六号楼") }, onClick = {  buildingsNumber =  "6"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "南七号楼") }, onClick = {  BuildingsNumber =  "7"
+            DropdownMenuItem(text = { Text(text = "南七号楼") }, onClick = {  buildingsNumber =  "7"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "南八号楼") }, onClick = {  BuildingsNumber =  "8"
+            DropdownMenuItem(text = { Text(text = "南八号楼") }, onClick = {  buildingsNumber =  "8"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "南九号楼") }, onClick = {  BuildingsNumber =  "9"
+            DropdownMenuItem(text = { Text(text = "南九号楼") }, onClick = {  buildingsNumber =  "9"
                 showitem = false})
-            DropdownMenuItem(text = { Text(text = "南十号楼") }, onClick = {  BuildingsNumber = "10"
+            DropdownMenuItem(text = { Text(text = "南十号楼") }, onClick = {  buildingsNumber = "10"
                 showitem = false})
         }
         DropdownMenu(expanded = showitem2, onDismissRequest = { showitem2 = false }, offset = it) {
-            DropdownMenuItem(text = { Text(text = "南边照明") }, onClick = { EndNumber = "11"
+            DropdownMenuItem(text = { Text(text = "南边照明") }, onClick = { endNumber = "11"
                 showitem2 = false})
-            DropdownMenuItem(text = { Text(text = "南边空调") }, onClick = { EndNumber = "12"
+            DropdownMenuItem(text = { Text(text = "南边空调") }, onClick = { endNumber = "12"
                 showitem2 = false})
-            DropdownMenuItem(text = { Text(text = "北边照明") }, onClick = { EndNumber = "21"
+            DropdownMenuItem(text = { Text(text = "北边照明") }, onClick = { endNumber = "21"
                 showitem2 = false})
-            DropdownMenuItem(text = { Text(text = "北边空调") }, onClick = { EndNumber = "22"
+            DropdownMenuItem(text = { Text(text = "北边空调") }, onClick = { endNumber = "22"
                 showitem2 = false})
         }
         DropdownMenu(expanded = showitem3, onDismissRequest = { showitem3 = false }, offset = it) {
-            DropdownMenuItem(text = { Text(text = "南边") }, onClick = { EndNumber = "11"
+            DropdownMenuItem(text = { Text(text = "南边") }, onClick = { endNumber = "11"
                 showitem3 = false })
-            DropdownMenuItem(text = { Text(text = "北边") }, onClick = { EndNumber = "21"
+            DropdownMenuItem(text = { Text(text = "北边") }, onClick = { endNumber = "21"
                 showitem3 = false })
         }
     }
 
     val scope = rememberCoroutineScope()
-    fun searchHefei() {
-        scope.launch {
-            val data = getHefeiElectric()
-            if(data == null) {
-                showToast("无")
-                return@launch
-            }
-            show = false
-            async { reEmptyLiveDta(vm.hefeiElectric) }.await()
-            async { vm.getFee("bearer $auth", FeeType.ELECTRIC_HEFEI_UNDERGRADUATE, room = data.roomNumber, building = data.buildingNumber) }.await()
-            async {
-                Handler(Looper.getMainLooper()).post{
-                    vm.hefeiElectric.observeForever { result ->
-                        if (result?.contains("success") == true) {
-                            try {
-                                val jsons = GsonInstance.fromJson(result, FeeResponse::class.java).map
-                                val data = jsons.showData
-                                for ((_, value) in data) {
-                                    scope.launch {
-                                        DataStoreManager.saveHefeiElectricFee(value)
-                                        show = true
-                                    }
-                                }
-                            } catch (e : Exception) {
-                                LogUtil.error(e)
-                                showToast("错误")
-                            }
-//                                                    val jsonObject = JSONObject(result)
-//                                                    val dataObject = jsonObject.getJSONObject("map").getJSONObject("data")
-//                                                    dataObject.put("myCustomInfo", "房间：$input")
-//                                                    json = dataObject.toString()
-//                                                    show = false
-                        }
+
+    // Hefei success context and state
+    var hefeiQueriedMeterKey by remember { mutableStateOf<String?>(null) }
+    var hefeiQueriedRoomName by remember { mutableStateOf("") }
+    var hefeiResultVisible by remember { mutableStateOf(false) }
+    var hefeiQueryLoading by remember { mutableStateOf(false) }
+    var hefeiQueryJob by remember { mutableStateOf<Job?>(null) }
+    var hefeiRequestId by remember { mutableLongStateOf(0L) }
+    var showHistoryPage by remember { mutableStateOf(false) }
+    var historyPageTab by remember { mutableIntStateOf(pagerState.currentPage) }
+    val hefeiHistoryViewModel = viewModel<ElectricHistoryViewModel>(key = "electric_history_hefei")
+    val xuanchengHistoryViewModel = viewModel<ElectricHistoryViewModel>(key = "electric_history_xuancheng")
+
+    fun searchXuancheng() {
+        xuanchengQueryJob?.cancel()
+        val requestId = ++xuanchengRequestId
+        xuanchengQueryJob = scope.launch {
+            if (requestId == xuanchengRequestId) xuanchengQueryLoading = true
+            showitem4 = false
+            // Snapshot immutable params
+            val queryBuildingsNumber = buildingsNumber
+            val queryRoomNumber = roomNumber
+            val queryEndNumber = endNumber
+            val queryRegion = region
+            val queryInput = "300$queryBuildingsNumber$queryRoomNumber$queryEndNumber"
+            val queryRoomName = "${queryBuildingsNumber}号楼${queryRoomNumber}寝室${queryRegion}"
+
+            try {
+                val result = withTimeoutOrNull(ELECTRIC_QUERY_TIMEOUT_MS.milliseconds) {
+                    vm.queryElectricFee(
+                        auth = "bearer $auth",
+                        type = FeeType.ELECTRIC_XUANCHENG,
+                        room = queryInput
+                    )
+                }
+                if (requestId != xuanchengRequestId) return@launch
+                if (result == null) {
+                    showToast("查询超时，请稍后重试")
+                    return@launch
+                }
+                if (!ElectricFeeResponseClassifier.isBusinessSuccess(result)) {
+                    showToast("未能获取电费信息")
+                    LogUtil.error("电费接口业务失败")
+                    return@launch
+                }
+                try {
+                    val jsons = GsonInstance.fromJson(result, FeeResponse::class.java).map
+                    val data = jsons.showData
+                    if (data.isEmpty()) {
+                        if (requestId == xuanchengRequestId) showToast("未获取到电费数据")
+                        return@launch
                     }
+                    var hasValidBalance = false
+                    for ((_, value) in data) {
+                        val balance = ElectricBalanceParser.parseXuanchengBalance(value)
+                        if (balance == null) {
+                            LogUtil.error("宣城余额解析失败")
+                            continue
+                        }
+                        if (requestId != xuanchengRequestId) return@launch
+                        hasValidBalance = true
+                        val meterKey = ElectricMeterKeyFactory.xuancheng(queryInput)
+                        val displayRoomCode = value.substringBefore("剩余金额").replace(":", "").trim()
+                        val displayBalance = balance.roundOffString(2)
+                        xuanchengRoomCodeText = displayRoomCode
+                        xuanchengBalanceText = displayBalance
+                        xuanchengResultVisible = true
+                        queriedMeterKey = meterKey
+                        queriedRoomName = queryRoomName
+                        DataStoreManager.saveXuanchengElectric(
+                            DataStoreManager.XuanchengElectricStorage(
+                                buildingNumber = queryBuildingsNumber,
+                                roomNumber = queryRoomNumber,
+                                endNumber = queryEndNumber,
+                                name = queryRoomName
+                            )
+                        )
+                        // Re-check before suspend call
+                        if (requestId != xuanchengRequestId) return@launch
+                        ElectricHistoryRepository.recordSnapshot(
+                            meterKey = meterKey,
+                            campusRegion = CampusRegion.XUANCHENG.description,
+                            roomName = queryRoomName,
+                            balance = balance
+                        )
+                    }
+                    if (!hasValidBalance && requestId == xuanchengRequestId) {
+                        showToast("未能解析电费余额")
+                        return@launch
+                    }
+                } catch (e : CancellationException) {
+                    throw e
+                } catch (e : Exception) {
+                    if (requestId != xuanchengRequestId) return@launch
+                    LogUtil.error(e)
+                    showToast("解析错误")
+                }
+                if (requestId != xuanchengRequestId) return@launch
+                try {
+                    val jsonObject = JSONObject(result)
+                    val dataObject = jsonObject.getJSONObject("map").getJSONObject("data")
+                    dataObject.put("myCustomInfo", "房间：$queryInput")
+                    val paymentJson = dataObject.toString()
+                    if (requestId != xuanchengRequestId) return@launch
+                    json = paymentJson
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    if (requestId != xuanchengRequestId) return@launch
+                    LogUtil.error(e)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HttpException) {
+                if (requestId != xuanchengRequestId) return@launch
+                val msg = when (e.code()) {
+                    401, 403 -> "登录状态已失效，请重新登录"
+                    else -> "服务器错误：${e.code()}"
+                }
+                showToast(msg)
+                LogUtil.error(e)
+            } catch (e: EmptyElectricResponseException) {
+                if (requestId != xuanchengRequestId) return@launch
+                showToast("服务器未返回电费数据")
+                LogUtil.error(e)
+            } catch (e: ElectricResponseReadException) {
+                if (requestId != xuanchengRequestId) return@launch
+                showToast("电费数据读取失败")
+                LogUtil.error(e)
+            } catch (e: java.io.IOException) {
+                if (requestId != xuanchengRequestId) return@launch
+                showToast("网络连接失败")
+                LogUtil.error(e)
+            } catch (e: Exception) {
+                if (requestId != xuanchengRequestId) return@launch
+                LogUtil.error(e)
+                showToast("电费查询失败")
+            } finally {
+                if (requestId == xuanchengRequestId) {
+                    xuanchengQueryLoading = false
+                    xuanchengQueryJob = null
                 }
             }
         }
     }
+
+    fun searchHefei() {
+        hefeiQueryJob?.cancel()
+        val requestId = ++hefeiRequestId
+        hefeiQueryJob = scope.launch {
+            if (requestId == hefeiRequestId) hefeiQueryLoading = true
+            try {
+                val data = getHefeiElectric()
+                if (data == null) {
+                    if (requestId == hefeiRequestId) showToast("请先选择寝室")
+                    return@launch
+                }
+                val queryBuildingNumber = data.buildingNumber
+                val queryRoomNumber = data.roomNumber
+                val queryRoomName = data.name
+                if (
+                    queryBuildingNumber.isBlank() ||
+                    queryRoomNumber.isBlank() ||
+                    queryRoomName.isBlank()
+                ) {
+                    if (requestId == hefeiRequestId) showToast("寝室配置不完整，请重新选择")
+                    return@launch
+                }
+                val queryMeterKey = ElectricMeterKeyFactory.hefei(
+                    queryBuildingNumber,
+                    queryRoomNumber
+                )
+                val result = withTimeoutOrNull(ELECTRIC_QUERY_TIMEOUT_MS.milliseconds) {
+                    vm.queryElectricFee(
+                        auth = "bearer $auth",
+                        type = FeeType.ELECTRIC_HEFEI_UNDERGRADUATE,
+                        room = queryRoomNumber,
+                        building = queryBuildingNumber
+                    )
+                }
+                if (requestId != hefeiRequestId) return@launch
+                if (result == null) {
+                    showToast("查询超时，请稍后重试")
+                    return@launch
+                }
+                if (!ElectricFeeResponseClassifier.isBusinessSuccess(result)) {
+                    showToast("未能获取电费信息")
+                    LogUtil.error("电费接口业务失败")
+                    return@launch
+                }
+                try {
+                    val jsons = GsonInstance.fromJson(result, FeeResponse::class.java).map
+                    val showData = jsons.showData
+                    if (showData.isEmpty()) {
+                        if (requestId == hefeiRequestId) showToast("未获取到电费数据")
+                        return@launch
+                    }
+                    var hasValidBalance = false
+                    for ((_, value) in showData) {
+                        val balance = ElectricBalanceParser.parseHefeiBalance(value)
+                        if (balance == null) {
+                            LogUtil.error("合肥余额解析失败")
+                            continue
+                        }
+                        if (requestId != hefeiRequestId) return@launch
+                        hasValidBalance = true
+                        hefeiResultVisible = true
+                        hefeiQueriedMeterKey = queryMeterKey
+                        hefeiQueriedRoomName = queryRoomName
+                        DataStoreManager.saveHefeiElectricFee(value)
+                        // Re-check after suspend call
+                        if (requestId != hefeiRequestId) return@launch
+                        ElectricHistoryRepository.recordSnapshot(
+                            meterKey = queryMeterKey,
+                            campusRegion = CampusRegion.HEFEI.description,
+                            roomName = queryRoomName,
+                            balance = balance
+                        )
+                    }
+                    if (!hasValidBalance && requestId == hefeiRequestId) {
+                        showToast("未能解析电费余额")
+                        return@launch
+                    }
+                } catch (e : CancellationException) {
+                    throw e
+                } catch (e : Exception) {
+                    if (requestId != hefeiRequestId) return@launch
+                    LogUtil.error(e)
+                    showToast("解析错误")
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: HttpException) {
+                if (requestId != hefeiRequestId) return@launch
+                val msg = when (e.code()) {
+                    401, 403 -> "登录状态已失效，请重新登录"
+                    else -> "服务器错误：${e.code()}"
+                }
+                showToast(msg)
+                LogUtil.error(e)
+            } catch (e: EmptyElectricResponseException) {
+                if (requestId != hefeiRequestId) return@launch
+                showToast("服务器未返回电费数据")
+                LogUtil.error(e)
+            } catch (e: ElectricResponseReadException) {
+                if (requestId != hefeiRequestId) return@launch
+                showToast("电费数据读取失败")
+                LogUtil.error(e)
+            } catch (e: java.io.IOException) {
+                if (requestId != hefeiRequestId) return@launch
+                showToast("网络连接失败")
+                LogUtil.error(e)
+            } catch (e: Exception) {
+                if (requestId != hefeiRequestId) return@launch
+                showToast("电费查询失败")
+                LogUtil.error(e)
+            } finally {
+                if (requestId == hefeiRequestId) {
+                    hefeiQueryLoading = false
+                    hefeiQueryJob = null
+                }
+            }
+        }
+    }
+
+    // Auto-query once on page entry if config is complete
+    var hasAutoQueried by remember { mutableStateOf(false) }
+    LaunchedEffect(restoredXuanchengElectric, pagerState.currentPage) {
+        if (hasAutoQueried) return@LaunchedEffect
+        when (pagerState.currentPage) {
+            HEFEI_TAB -> {
+                hasAutoQueried = true
+                searchHefei()
+            }
+            XUANCHENG_TAB -> {
+                if (!restoredXuanchengElectric) return@LaunchedEffect
+                hasAutoQueried = true
+                if (buildingsNumber.isNotBlank() && roomNumber.isNotBlank() && endNumber.isNotBlank()) {
+                    searchXuancheng()
+                }
+            }
+        }
+    }
+
     Column(modifier = Modifier) {
-        HazeBottomSheetTopBar("寝室电费" , isPaddingStatusBar = false) {
+        HazeBottomSheetTopBar(if(showHistoryPage) "余额记录" else "寝室电费" , isPaddingStatusBar = false) {
+            if(showHistoryPage) {
+                IconButton(onClick = { showHistoryPage = false }) {
+                    Icon(painter = painterResource(R.drawable.arrow_back), contentDescription = "back")
+                }
+            } else {
                 Row() {
                     if(showitem4)
-                        IconButton(onClick = {RoomNumber = RoomNumber.replaceFirst(".$".toRegex(), "")}) {
+                        IconButton(onClick = {roomNumber = roomNumber.replaceFirst(".$".toRegex(), "")}) {
                             Icon(painter = painterResource(R.drawable.backspace), contentDescription = "description") }
                     FilledTonalIconButton(onClick = {
                         when(pagerState.currentPage) {
@@ -374,41 +662,7 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                 searchHefei()
                             }
                             XUANCHENG_TAB -> {
-                                scope.launch {
-                                    show = false
-                                    async {
-                                        showitem4 = false
-                                        reEmptyLiveDta(vm.electricData)
-                                        SharedPrefs.saveString("BuildNumber", BuildingsNumber)
-                                        SharedPrefs.saveString("EndNumber", EndNumber)
-                                        SharedPrefs.saveString("RoomNumber", RoomNumber)
-                                        SharedPrefs.saveString("RoomText","${BuildingsNumber}号楼${RoomNumber}寝室${region}" )
-                                    }.await()
-                                    async { vm.getFee("bearer $auth", FeeType.ELECTRIC_XUANCHENG, room = input) }.await()
-                                    async {
-                                        Handler(Looper.getMainLooper()).post{
-                                            vm.electricData.observeForever { result ->
-                                                if (result?.contains("success") == true) {
-                                                    try {
-                                                        val jsons = GsonInstance.fromJson(result, FeeResponse::class.java).map
-                                                        val data = jsons.showData
-                                                        for ((_, value) in data) {
-                                                            Result = value
-                                                        }
-                                                    } catch (e : Exception) {
-                                                        LogUtil.error(e)
-                                                        showToast("错误")
-                                                    }
-                                                    val jsonObject = JSONObject(result)
-                                                    val dataObject = jsonObject.getJSONObject("map").getJSONObject("data")
-                                                    dataObject.put("myCustomInfo", "房间：$input")
-                                                    json = dataObject.toString()
-                                                    show = false
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                                searchXuancheng()
                             }
                         }
                     }) { Icon(painter = painterResource(R.drawable.search), contentDescription = "description") }
@@ -423,31 +677,50 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                         Text("官方充值")
                     }
                 }
+            }
         }
-        if (BuildingsNumber == "0") BuildingsNumber = ""
-        LaunchedEffect(pagerState.currentPage) {
-            show = false
+        if (buildingsNumber == "0") buildingsNumber = ""
+        if(!showHistoryPage) {
+            // Pager switch does NOT clear either campus result
+            CustomTabRow(pagerState,titles)
         }
-        CustomTabRow(pagerState,titles)
+        ShareTwoContainer2D(
+            modifier = Modifier.fillMaxWidth(),
+            show = showHistoryPage,
+            defaultContent = {
         Column(
         ) {
             HorizontalPager(state = pagerState) { page ->
                 when(page) {
                     HEFEI_TAB -> {
-                        Column {
-                            ElectricHefei(vm,show) {
-                                searchHefei()
+                        LazyColumn {
+                            item {
+                                ElectricHefei(
+                                    vm,
+                                    hefeiResultVisible,
+                                    hefeiQueryLoading,
+                                    hefeiQueriedMeterKey,
+                                    hefeiQueriedRoomName,
+                                    hefeiHistoryViewModel,
+                                    onOpenRecords = {
+                                        historyPageTab = HEFEI_TAB
+                                        showHistoryPage = true
+                                    }
+                                ) {
+                                    searchHefei()
+                                }
                             }
                         }
                     }
                     XUANCHENG_TAB -> {
-                        Column {
-                            Row(modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = APP_HORIZONTAL_DP, vertical = 0.dp), horizontalArrangement = Arrangement.Start) {
+                        LazyColumn {
+                            item {
+                                Row(modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = APP_HORIZONTAL_DP, vertical = 0.dp), horizontalArrangement = Arrangement.Start) {
 
                                 MenuChip(
-                                    label = { Text(text = "楼栋 $BuildingsNumber") },
+                                    label = { Text(text = "楼栋 $buildingsNumber") },
                                 ) {
                                     menuOffset = it
                                     showitem = true
@@ -461,10 +734,10 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                 ) {
                                     menuOffset = it
                                     when {
-                                        BuildingsNumber.toIntOrNull() != null -> {
+                                        buildingsNumber.toIntOrNull() != null -> {
                                             when {
-                                                BuildingsNumber.toInt() > 5 -> showitem2 = true
-                                                BuildingsNumber.toInt() in 1..5 -> showitem3 = true
+                                                buildingsNumber.toInt() > 5 -> showitem2 = true
+                                                buildingsNumber.toInt() in 1..5 -> showitem3 = true
                                             }
                                         }
                                         else -> Toast.makeText(MyApplication.context,"请选择楼栋", Toast.LENGTH_SHORT).show()
@@ -474,15 +747,12 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                 Spacer(modifier = Modifier.width(10.dp))
                                 AssistChip(
                                     onClick = { showitem4 = !showitem4 },
-                                    label = { Text(text = "寝室 ${RoomNumber}") },
+                                    label = { Text(text = "寝室 $roomNumber") },
                                     //leadingIcon = { Icon(painter = painterResource(R.drawable.add), contentDescription = "description") }
                                 )
                             }
-
-                            // Spacer(modifier = Modifier.height(7.dp))
-
-//充值界面
-//        Spacer(modifier = Modifier.height(7.dp))
+                            }
+                            item {
                             AnimatedVisibility(
                                 visible = showitem4,
                                 enter = slideInVertically(
@@ -497,35 +767,29 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                             ){
                                 Row (modifier = Modifier.padding(horizontal = APP_HORIZONTAL_DP)){
                                     OutlinedCard{
-                                        LazyColumn(modifier = Modifier.padding(horizontal = 10.dp)) {
-                                            item {
-                                                Text(text = " 选取寝室号", modifier = Modifier.padding(10.dp))
-                                            }
-                                            item {
-                                                LazyRow {
-                                                    items(5) { items ->
-                                                        IconButton(onClick = {
-                                                            if (RoomNumber.length < 3)
-                                                                RoomNumber += items.toString()
-                                                            else Toast.makeText(
-                                                                MyApplication.context,
-                                                                "三位数",
-                                                                Toast.LENGTH_SHORT
-                                                            ).show()
-                                                        }) { Text(text = items.toString()) }
-                                                    }
+                                        Column(modifier = Modifier.padding(horizontal = 10.dp)) {
+                                            Text(text = " 选取寝室号", modifier = Modifier.padding(10.dp))
+                                            LazyRow {
+                                                items(5) { items ->
+                                                    IconButton(onClick = {
+                                                        if (roomNumber.length < 3)
+                                                            roomNumber += items.toString()
+                                                        else Toast.makeText(
+                                                            MyApplication.context,
+                                                            "三位数",
+                                                            Toast.LENGTH_SHORT
+                                                        ).show()
+                                                    }) { Text(text = items.toString()) }
                                                 }
                                             }
-                                            item {
-                                                LazyRow {
-                                                    items(5) { items ->
-                                                        val num = items + 5
-                                                        IconButton(onClick = {
-                                                            if (RoomNumber.length < 3)
-                                                                RoomNumber += num
-                                                            else Toast.makeText(MyApplication.context, "三位数", Toast.LENGTH_SHORT).show()
-                                                        }) { Text(text = num.toString()) }
-                                                    }
+                                            LazyRow {
+                                                items(5) { items ->
+                                                    val num = items + 5
+                                                    IconButton(onClick = {
+                                                        if (roomNumber.length < 3)
+                                                            roomNumber += num
+                                                        else Toast.makeText(MyApplication.context, "三位数", Toast.LENGTH_SHORT).show()
+                                                    }) { Text(text = num.toString()) }
                                                 }
                                             }
                                         }
@@ -533,26 +797,18 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                     }
                                 }
                             }
-
-                            if(Result.contains("剩余金额")){
-                                Result2 = "剩余金额 " +Result.substringAfter("剩余金额")
-                                Result2 = Result2.replace(":","")
-                                Result = Result.substringBefore("剩余金额").replace(":","")
-                                show = true
-
-                            } else if(Result.contains("无法获取房间信息") || Result.contains("hfut")) Result2 = "失败"
-
-
+                            }
+                            item {
                             DividerTextExpandedWith(text = "查询结果",openBlurAnimation = false) {
                                 LoadingLargeCard(
-                                    title = if(!show)"￥XX.XX"
+                                    title = if(!xuanchengResultVisible)"￥XX.XX"
                                     else
-                                        "￥${Result2.substringAfter(" ").toDouble().roundOffString(2)}",
-                                    loading = !show ,
+                                        "￥${xuanchengBalanceText}",
+                                    loading = xuanchengQueryLoading ,
                                     prepare = true,
                                     rightTop = {
                                         FilledTonalButton(
-                                            enabled = show,
+                                            enabled = xuanchengResultVisible,
                                             onClick = {
                                                 if(showAdd && payNumber != "")
                                                     showBottomSheet = true
@@ -569,13 +825,15 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                     }
                                 ) {
                                     TransplantListItem(
-                                        overlineContent = {Text( text = if(!show)"房间号 " + " 300XXXXX1" else "房间号 " + Result.substringAfter(" ")  )},
-                                        headlineContent = { (if(!show)"X号楼XXX寝室方向设施" else prefs.getString("RoomText",null))?.let { Text(text = it) } },
+                                        overlineContent = {Text( text = if(!xuanchengResultVisible)"房间号 " + " 300XXXXX1" else "房间号 $xuanchengRoomCodeText" )},
+                                        headlineContent = { (if(!xuanchengResultVisible)"X号楼XXX寝室方向设施" else queriedRoomName.ifEmpty { null })?.let { Text(text = it) } },
                                         leadingContent = { Icon(painter = painterResource(id = R.drawable.info), contentDescription = "")}
                                     )
                                 }
                                 Spacer(modifier = Modifier.height(APP_HORIZONTAL_DP/2))
                             }
+                            }
+                            item {
                             DividerTextExpandedWith("使用说明", defaultIsExpanded = false) {
                                 CustomCard(
                                     color = cardNormalColor()
@@ -604,6 +862,18 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                                     )
                                 }
                             }
+                            }
+                            item {
+                            ElectricHistorySection(
+                                meterKey = queriedMeterKey,
+                                roomName = queriedRoomName,
+                                viewModel = xuanchengHistoryViewModel,
+                                onOpenRecords = {
+                                    historyPageTab = XUANCHENG_TAB
+                                    showHistoryPage = true
+                                }
+                            )
+                            }
                         }
                     }
                 }
@@ -612,6 +882,13 @@ fun EleUI(vm : NetWorkViewModel, hazeState: HazeState) {
                 .height(APP_HORIZONTAL_DP)
                 .navigationBarsPadding())
         }
+            },
+            secondContent = {
+            ElectricBalanceRecordPage(
+                viewModel = if(historyPageTab == HEFEI_TAB) hefeiHistoryViewModel else xuanchengHistoryViewModel
+            )
+            }
+        )
     }
 }
 
@@ -623,7 +900,12 @@ private enum class ExpandState {
 @Composable
 fun ElectricHefei(
     vm : NetWorkViewModel,
-    show : Boolean,
+    hefeiResultVisible : Boolean,
+    hefeiQueryLoading : Boolean,
+    hefeiQueriedMeterKey : String?,
+    hefeiQueriedRoomName : String,
+    hefeiHistoryViewModel: ElectricHistoryViewModel,
+    onOpenRecords: () -> Unit,
     search : () -> Unit
 ) {
     var expandState by remember { mutableStateOf(ExpandState.NONE) }
@@ -858,7 +1140,7 @@ fun ElectricHefei(
         }
     )
     var useLocal by remember { mutableStateOf(false) }
-    val savedData by produceState<HefeiElectricStorage?>(initialValue = null, key1 = show) {
+    val savedData by produceState<HefeiElectricStorage?>(initialValue = null, key1 = hefeiResultVisible) {
         value = getHefeiElectric()
     }
 
@@ -891,12 +1173,12 @@ fun ElectricHefei(
     val result by DataStoreManager.hefeiElectricFee.collectAsState(initial = "XX.XX")
     DividerTextExpandedWith("查询结果",openBlurAnimation = false) {
         LoadingLargeCard(
-            title = if(!show)"￥XX.XX" else "￥$result",
-            loading = !show ,
+            title = if(!hefeiResultVisible)"￥XX.XX" else "￥$result",
+            loading = hefeiQueryLoading ,
             prepare = true,
             rightTop = {
                 FilledTonalButton(
-                    enabled = show,
+                    enabled = hefeiResultVisible,
                     onClick = {
                         showToast("正在开发")
                     }
@@ -918,6 +1200,13 @@ fun ElectricHefei(
         }
         BottomTip("快速充值开发中 请先使用官方充值")
     }
+
+    ElectricHistorySection(
+        meterKey = hefeiQueriedMeterKey,
+        roomName = hefeiQueriedRoomName,
+        viewModel = hefeiHistoryViewModel,
+        onOpenRecords = onOpenRecords
+    )
 }
 
 private fun getBuildingStr(content : Int, campus : Campus) : String {

--- a/app/src/main/java/com/hfut/schedule/ui/style/special/HazeBlur.kt
+++ b/app/src/main/java/com/hfut/schedule/ui/style/special/HazeBlur.kt
@@ -251,6 +251,7 @@ fun Modifier.bottomSheetBlur(hazeState: HazeState) : Modifier = blurStyle(hazeSt
 fun HazeBottomSheet(
     showBottomSheet : Boolean,
     onDismissRequest : () -> Unit,
+    sheetGesturesEnabled : Boolean = true,
     content : @Composable () -> Unit
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -266,6 +267,7 @@ fun HazeBottomSheet(
         sheetState = sheetState,
         dragHandle = null,
         containerColor = MaterialTheme.colorScheme.surface,
+        sheetGesturesEnabled = sheetGesturesEnabled,
         shape = bottomSheetRound(sheetState, isFullScreen)
     ) {
         Column(modifier = Modifier

--- a/app/src/main/java/com/hfut/schedule/viewmodel/network/NetWorkViewModel.kt
+++ b/app/src/main/java/com/hfut/schedule/viewmodel/network/NetWorkViewModel.kt
@@ -418,6 +418,27 @@ class NetWorkViewModel() : ViewModel() {
     val hefeiElectric = MutableLiveData<String?>()
     fun getFee(auth: String,type : FeeType,room : String? = null,phoneNumber : String? = null,building : String? = null) = HuiXinRepository.getFee(auth,type,room,phoneNumber, building,hefeiElectric,infoValue, electricData, showerData)
 
+    /**
+     * Suspend API for electric fee queries. Each call gets its own Retrofit Call,
+     * so concurrent requests for different rooms cannot interfere.
+     *
+     * @return response body string (non-null, non-blank)
+     * @throws retrofit2.HttpException on HTTP non-2xx
+     * @throws java.io.IOException on empty body or read failure
+     * @throws Exception on network failure
+     */
+    suspend fun queryElectricFee(
+        auth: String,
+        type: FeeType,
+        room: String? = null,
+        building: String? = null
+    ): String = HuiXinRepository.queryFeeRaw(
+        auth = auth,
+        type = type,
+        room = room,
+        building = building
+    )
+
     val guaGuaUserInfo = MutableLiveData<String?>()
     fun getGuaGuaUserInfo() = GuaGuaRepository.getGuaGuaUserInfo(guaGuaUserInfo)
 

--- a/app/src/main/java/com/hfut/schedule/viewmodel/ui/ElectricHistoryViewModel.kt
+++ b/app/src/main/java/com/hfut/schedule/viewmodel/ui/ElectricHistoryViewModel.kt
@@ -1,0 +1,157 @@
+package com.hfut.schedule.viewmodel.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
+import com.hfut.schedule.logic.database.model.ElectricUsageSummary
+import com.hfut.schedule.logic.database.repository.ElectricHistoryRepository
+import com.hfut.schedule.logic.database.util.ElectricUsageCalculator
+import com.xah.common.logic.util.LogUtil
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+enum class ElectricChartMode {
+    BALANCE,
+    CONSUMPTION_RATE
+}
+
+enum class ElectricHistoryRange {
+    SEVEN_DAYS,
+    THIRTY_DAYS,
+    ALL
+}
+
+data class ElectricHistoryUiState(
+    val meterKey: String? = null,
+    val roomName: String = "",
+    val allRecords: List<ElectricBalanceRecordEntity> = emptyList(),
+    val filteredRecords: List<ElectricBalanceRecordEntity> = emptyList(),
+    val summary: ElectricUsageSummary? = null,
+    val chartMode: ElectricChartMode = ElectricChartMode.BALANCE,
+    val range: ElectricHistoryRange = ElectricHistoryRange.THIRTY_DAYS,
+    val recent7DaysConsumption: Double = 0.0,
+    val totalRecordCount: Int = 0
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ElectricHistoryViewModel : ViewModel() {
+
+    private val _meterKey = MutableStateFlow<String?>(null)
+    private val _roomName = MutableStateFlow("")
+    private val _selectedRange = MutableStateFlow(ElectricHistoryRange.THIRTY_DAYS)
+    private val _chartMode = MutableStateFlow(ElectricChartMode.BALANCE)
+
+    val uiState: StateFlow<ElectricHistoryUiState> =
+        combine(
+            _meterKey,
+            _roomName,
+            _selectedRange,
+            _chartMode
+        ) { key, roomName, range, mode ->
+            ElectricHistoryUiState(
+                meterKey = key,
+                roomName = roomName,
+                chartMode = mode,
+                range = range
+            )
+        }.flatMapLatest { state ->
+            val key = state.meterKey
+            if (key == null) {
+                flowOf(state)
+            } else {
+                ElectricHistoryRepository.observeHistory(key).map { records ->
+                    val compactRecords = compactConsecutiveDuplicateBalances(records)
+                    val filtered = filterRecordsByRange(compactRecords, state.range)
+                    val summary = try {
+                        ElectricUsageCalculator.calculate(filtered)
+                    } catch (e: IllegalArgumentException) {
+                        LogUtil.error(e, "计算电费历史摘要失败")
+                        null
+                    }
+                    val recent7Days = try {
+                        ElectricUsageCalculator.calculateRecent7DaysConsumption(compactRecords)
+                    } catch (e: IllegalArgumentException) {
+                        LogUtil.error(e, "计算电费历史统计失败")
+                        0.0
+                    }
+                    state.copy(
+                        allRecords = compactRecords,
+                        filteredRecords = filtered,
+                        summary = summary,
+                        recent7DaysConsumption = recent7Days,
+                        totalRecordCount = compactRecords.size
+                    )
+                }
+            }
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            ElectricHistoryUiState()
+        )
+
+    fun setMeterKey(meterKey: String?, roomName: String) {
+        _meterKey.value = meterKey
+        _roomName.value = roomName
+    }
+
+    fun setRange(range: ElectricHistoryRange) {
+        _selectedRange.value = range
+    }
+
+    fun setChartMode(mode: ElectricChartMode) {
+        _chartMode.value = mode
+    }
+
+    fun clearHistory() {
+        val key = _meterKey.value ?: return
+        viewModelScope.launch {
+            ElectricHistoryRepository.clearHistory(key)
+        }
+    }
+
+    private fun filterRecordsByRange(
+        records: List<ElectricBalanceRecordEntity>,
+        range: ElectricHistoryRange
+    ): List<ElectricBalanceRecordEntity> {
+        if (range == ElectricHistoryRange.ALL) return records
+
+        val now = System.currentTimeMillis()
+        val durationMs = when (range) {
+            ElectricHistoryRange.SEVEN_DAYS -> 7 * 24 * 60 * 60 * 1000L
+            ElectricHistoryRange.THIRTY_DAYS -> 30 * 24 * 60 * 60 * 1000L
+            ElectricHistoryRange.ALL -> return records
+        }
+        val cutoff = now - durationMs
+        return records.filter { it.sampledAt >= cutoff }
+    }
+
+    private fun compactConsecutiveDuplicateBalances(
+        records: List<ElectricBalanceRecordEntity>
+    ): List<ElectricBalanceRecordEntity> {
+        if (records.size < 2) return records
+
+        val sorted = records.sortedBy { it.sampledAt }
+        val compacted = mutableListOf<ElectricBalanceRecordEntity>()
+        var pending = sorted.first()
+
+        for (record in sorted.drop(1)) {
+            val sameBalance = kotlin.math.abs(record.remainingBalance - pending.remainingBalance) <= 0.005
+            if (sameBalance) {
+                pending = record
+            } else {
+                compacted.add(pending)
+                pending = record
+            }
+        }
+        compacted.add(pending)
+        return compacted
+    }
+}

--- a/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricBalanceParserTest.kt
+++ b/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricBalanceParserTest.kt
@@ -1,0 +1,159 @@
+package com.hfut.schedule.logic.database.util
+
+import com.hfut.schedule.logic.enumeration.CampusRegion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ElectricBalanceParserTest {
+
+    @Test
+    fun `parseHefeiBalance normal amount`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("123.45")
+        assertEquals(123.45, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseHefeiBalance with RMB symbol`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("￥123.45")
+        assertEquals(123.45, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseHefeiBalance with Yen symbol`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("¥50.00")
+        assertEquals(50.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseHefeiBalance empty string`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseHefeiBalance placeholder XX`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("XX.XX")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseHefeiBalance placeholder dashes`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("--")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseHefeiBalance illegal string`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("abc")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseHefeiBalance with spaces`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("  123.45  ")
+        assertEquals(123.45, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance with half-width colon`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额:12.34")
+        assertEquals(12.34, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance with full-width colon`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额：12.34")
+        assertEquals(12.34, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance with room info`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("房间号 3001011111 剩余金额:45.67")
+        assertEquals(45.67, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance without remaining amount`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("无法获取房间信息")
+        assertNull(result)
+    }
+
+    @Test
+    fun `parseXuanchengBalance with space after colon`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额: 99.99")
+        assertEquals(99.99, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance with spaces around keyword`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额 50.00")
+        assertEquals(50.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `parse with null value`() {
+        val result = ElectricBalanceParser.parse(null, CampusRegion.HEFEI)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse with blank value`() {
+        val result = ElectricBalanceParser.parse("   ", CampusRegion.HEFEI)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse NaN value`() {
+        val result = ElectricBalanceParser.parse("NaN", CampusRegion.HEFEI)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse Infinity value`() {
+        val result = ElectricBalanceParser.parse("Infinity", CampusRegion.HEFEI)
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse negative value`() {
+        val result = ElectricBalanceParser.parse("-50.00", CampusRegion.HEFEI)
+        assertEquals(-50.0, result!!, 0.001)
+    }
+
+    @Test
+    fun `extremely negative balance is rejected by threshold`() {
+        // -2000.00 is parsed but rejected by validateBalance (threshold < -1000.0)
+        assertNull(ElectricBalanceParser.parseHefeiBalance("-2000.00"))
+    }
+
+    @Test
+    fun `parseXuanchengBalance accepts reasonable negative balance`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额:-5.20")
+        assertEquals(-5.20, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance accepts negative balance with full width colon`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("剩余金额： -5.20")
+        assertEquals(-5.20, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseXuanchengBalance rejects extremely negative balance by threshold`() {
+        // -2000.00 is parsed by regex but rejected by validateBalance (threshold < -1000.0)
+        assertNull(ElectricBalanceParser.parseXuanchengBalance("剩余金额:-2000.00"))
+    }
+
+    @Test
+    fun `parseXuanchengBalance negative with room info`() {
+        val result = ElectricBalanceParser.parseXuanchengBalance("房间号 3001011111 剩余金额:-3.50")
+        assertEquals(-3.50, result!!, 0.001)
+    }
+
+    @Test
+    fun `parseHefeiBalance negative value`() {
+        val result = ElectricBalanceParser.parseHefeiBalance("-5.20")
+        assertEquals(-5.20, result!!, 0.001)
+    }
+}

--- a/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricMeterKeyFactoryTest.kt
+++ b/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricMeterKeyFactoryTest.kt
@@ -1,0 +1,141 @@
+package com.hfut.schedule.logic.database.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ElectricMeterKeyFactoryTest {
+
+    @Test
+    fun `hefei key format`() {
+        val key = ElectricMeterKeyFactory.hefei("1", "101")
+        assertEquals("HEFEI:1:101", key)
+    }
+
+    @Test
+    fun `hefei key with different rooms`() {
+        val key1 = ElectricMeterKeyFactory.hefei("1", "101")
+        val key2 = ElectricMeterKeyFactory.hefei("1", "102")
+        assertNotEquals(key1, key2)
+    }
+
+    @Test
+    fun `hefei key with different buildings`() {
+        val key1 = ElectricMeterKeyFactory.hefei("1", "101")
+        val key2 = ElectricMeterKeyFactory.hefei("2", "101")
+        assertNotEquals(key1, key2)
+    }
+
+    @Test
+    fun `xuancheng key format`() {
+        val key = ElectricMeterKeyFactory.xuancheng("3001011111")
+        assertEquals("XUANCHENG:3001011111", key)
+    }
+
+    @Test
+    fun `xuancheng key with different inputs`() {
+        val key1 = ElectricMeterKeyFactory.xuancheng("3001011111")
+        val key2 = ElectricMeterKeyFactory.xuancheng("3001011112")
+        assertNotEquals(key1, key2)
+    }
+
+    @Test
+    fun `xuancheng key with air conditioning suffix`() {
+        val key1 = ElectricMeterKeyFactory.xuancheng("3001011112")
+        val key2 = ElectricMeterKeyFactory.xuancheng("3001011122")
+        assertNotEquals(key1, key2)
+    }
+
+    @Test
+    fun `hefei and xuancheng keys are different`() {
+        val hefeiKey = ElectricMeterKeyFactory.hefei("1", "101")
+        val xuanchengKey = ElectricMeterKeyFactory.xuancheng("1:101")
+        assertNotEquals(hefeiKey, xuanchengKey)
+    }
+
+    @Test
+    fun `hefei key trims whitespace`() {
+        val key = ElectricMeterKeyFactory.hefei(" 1 ", " 101 ")
+        assertEquals("HEFEI:1:101", key)
+    }
+
+    @Test
+    fun `xuancheng key trims whitespace`() {
+        val key = ElectricMeterKeyFactory.xuancheng(" 3001011111 ")
+        assertEquals("XUANCHENG:3001011111", key)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `hefei key rejects empty buildingNumber`() {
+        ElectricMeterKeyFactory.hefei("", "101")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `hefei key rejects empty roomNumber`() {
+        ElectricMeterKeyFactory.hefei("1", "")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `hefei key rejects both empty`() {
+        ElectricMeterKeyFactory.hefei("", "")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `hefei key rejects blank buildingNumber`() {
+        ElectricMeterKeyFactory.hefei("  ", "101")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `xuancheng key rejects empty input`() {
+        ElectricMeterKeyFactory.xuancheng("")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `xuancheng key rejects blank input`() {
+        ElectricMeterKeyFactory.xuancheng("   ")
+    }
+
+    // isValid tests
+
+    @Test
+    fun `isValid returns true for valid hefei key`() {
+        assertTrue(ElectricMeterKeyFactory.isValid("HEFEI:1:101"))
+    }
+
+    @Test
+    fun `isValid returns true for valid xuancheng key`() {
+        assertTrue(ElectricMeterKeyFactory.isValid("XUANCHENG:3001011111"))
+    }
+
+    @Test
+    fun `isValid returns false for HEFEI with empty room`() {
+        assertFalse(ElectricMeterKeyFactory.isValid("HEFEI:1:"))
+    }
+
+    @Test
+    fun `isValid returns false for HEFEI with empty building`() {
+        assertFalse(ElectricMeterKeyFactory.isValid("HEFEI::101"))
+    }
+
+    @Test
+    fun `isValid returns false for HEFEI with both empty`() {
+        assertFalse(ElectricMeterKeyFactory.isValid("HEFEI::"))
+    }
+
+    @Test
+    fun `isValid returns false for XUANCHENG with empty input`() {
+        assertFalse(ElectricMeterKeyFactory.isValid("XUANCHENG:"))
+    }
+
+    @Test
+    fun `isValid returns false for unknown prefix`() {
+        assertFalse(ElectricMeterKeyFactory.isValid("OTHER:1:101"))
+    }
+
+    @Test
+    fun `isValid returns false for empty string`() {
+        assertFalse(ElectricMeterKeyFactory.isValid(""))
+    }
+}

--- a/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricResponseClassifierTest.kt
+++ b/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricResponseClassifierTest.kt
@@ -1,0 +1,235 @@
+package com.hfut.schedule.logic.database.util
+
+import com.hfut.schedule.logic.network.util.ElectricFeeResponseClassifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for [ElectricFeeResponseClassifier] which classifies
+ * HuiXin electric fee API responses as business success or failure.
+ * All tests directly call the production classifier.
+ */
+class ElectricResponseClassifierTest {
+
+    // === Should be SUCCESS ===
+
+    @Test
+    fun `msg success with map showData`() {
+        assertTrue(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":"success","map":{"showData":{"a":"1"}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `msg Success case insensitive`() {
+        assertTrue(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":"Success","map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `success true boolean`() {
+        assertTrue(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":true}"""
+            )
+        )
+    }
+
+    @Test
+    fun `map with showData only`() {
+        assertTrue(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"map":{"showData":{"a":"1"}}}"""
+            )
+        )
+    }
+
+    // === Should be FAILURE ===
+
+    @Test
+    fun `success false overrides map showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":false,"map":{"showData":{"a":"1"}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `msg failed overrides map showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"map":{"showData":{"a":"1"}},"msg":"failed"}"""
+            )
+        )
+    }
+
+    @Test
+    fun `showData outside map is not success`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"map":{},"other":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `message unsuccessful is failure`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"message":"unsuccessful"}"""
+            )
+        )
+    }
+
+    @Test
+    fun `success text inside json string is failure`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"message":"response contains \"success\":true"}"""
+            )
+        )
+    }
+
+    @Test
+    fun `non json text containing msg success is failure`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """server output: "msg":"success" end"""
+            )
+        )
+    }
+
+    @Test
+    fun `null body is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess(null))
+    }
+
+    @Test
+    fun `empty string is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess(""))
+    }
+
+    @Test
+    fun `blank string is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess("   "))
+    }
+
+    @Test
+    fun `json array root is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess("[]"))
+    }
+
+    @Test
+    fun `json number root is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess("123"))
+    }
+
+    @Test
+    fun `json boolean root is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess("true"))
+    }
+
+    @Test
+    fun `json with map but no showData is failure`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"map":{"data":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `non json text is failure`() {
+        assertFalse(ElectricFeeResponseClassifier.isBusinessSuccess("this is not json"))
+    }
+
+    @Test
+    fun `json without success field and without map is failure`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"data":"some value"}"""
+            )
+        )
+    }
+
+    // === Field type boundary tests ===
+
+    @Test
+    fun `numeric success field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":1,"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `numeric msg field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":123,"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `null success field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":null,"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `null msg field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":null,"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `string success field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":"true","map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `boolean msg field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":true,"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `object success field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"success":{},"map":{"showData":{}}}"""
+            )
+        )
+    }
+
+    @Test
+    fun `array msg field is failure even with showData`() {
+        assertFalse(
+            ElectricFeeResponseClassifier.isBusinessSuccess(
+                """{"msg":[],"map":{"showData":{}}}"""
+            )
+        )
+    }
+}

--- a/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricUsageCalculatorTest.kt
+++ b/app/src/test/java/com/hfut/schedule/logic/database/util/ElectricUsageCalculatorTest.kt
@@ -1,0 +1,379 @@
+package com.hfut.schedule.logic.database.util
+
+import com.hfut.schedule.logic.database.entity.ElectricBalanceRecordEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Calendar
+
+class ElectricUsageCalculatorTest {
+
+    private fun createRecord(
+        id: Long = 0,
+        meterKey: String = "HEFEI:1:101",
+        campusRegion: String = "合肥",
+        roomName: String = "1号楼101寝室",
+        remainingBalance: Double,
+        sampledAt: Long
+    ) = ElectricBalanceRecordEntity(
+        id = id,
+        meterKey = meterKey,
+        campusRegion = campusRegion,
+        roomName = roomName,
+        remainingBalance = remainingBalance,
+        sampledAt = sampledAt
+    )
+
+    private fun timeAt(
+        year: Int = 2026,
+        month: Int = Calendar.JUNE,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ): Long = Calendar.getInstance().apply {
+        set(Calendar.YEAR, year)
+        set(Calendar.MONTH, month)
+        set(Calendar.DAY_OF_MONTH, day)
+        set(Calendar.HOUR_OF_DAY, hour)
+        set(Calendar.MINUTE, minute)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
+
+    @Test
+    fun `empty records`() {
+        val summary = ElectricUsageCalculator.calculate(emptyList())
+        assertNull(summary.latestBalance)
+        assertNull(summary.firstSampleAt)
+        assertNull(summary.latestSampleAt)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertNull(summary.averageDailyConsumption)
+        assertNull(summary.estimatedRemainingDays)
+        assertEquals(0, summary.validIntervalCount)
+        assertTrue(summary.increases.isEmpty())
+        assertTrue(summary.intervals.isEmpty())
+    }
+
+    @Test
+    fun `single record`() {
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = 1000L)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(100.0, summary.latestBalance!!, 0.001)
+        assertEquals(1000L, summary.firstSampleAt)
+        assertEquals(1000L, summary.latestSampleAt)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertEquals(0, summary.validIntervalCount)
+    }
+
+    @Test
+    fun `two records with balance decrease`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(90.0, summary.latestBalance!!, 0.001)
+        assertEquals(10.0, summary.totalConsumed, 0.001)
+        assertEquals(1, summary.validIntervalCount)
+        assertNotNull(summary.averageDailyConsumption)
+        assertEquals(10.0, summary.averageDailyConsumption!!, 0.001)
+    }
+
+    @Test
+    fun `multiple consecutive decreases`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 3 * dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now - 2 * dayMs),
+            createRecord(remainingBalance = 80.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 70.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(70.0, summary.latestBalance!!, 0.001)
+        assertEquals(30.0, summary.totalConsumed, 0.001)
+        assertEquals(3, summary.validIntervalCount)
+        assertEquals(10.0, summary.averageDailyConsumption!!, 0.001)
+    }
+
+    @Test
+    fun `balance unchanged`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 100.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(100.0, summary.latestBalance!!, 0.001)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertEquals(0, summary.validIntervalCount)
+        assertNull(summary.averageDailyConsumption)
+    }
+
+    @Test
+    fun `balance increase (recharge)`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 50.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 150.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(150.0, summary.latestBalance!!, 0.001)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertEquals(0, summary.validIntervalCount)
+        assertEquals(1, summary.increases.size)
+        assertEquals(100.0, summary.increases[0].amount, 0.001)
+    }
+
+    @Test
+    fun `decrease then increase then decrease`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 3 * dayMs),
+            createRecord(remainingBalance = 80.0, sampledAt = now - 2 * dayMs),
+            createRecord(remainingBalance = 200.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 190.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(190.0, summary.latestBalance!!, 0.001)
+        assertEquals(30.0, summary.totalConsumed, 0.001)
+        assertEquals(2, summary.validIntervalCount)
+        assertEquals(1, summary.increases.size)
+        assertEquals(120.0, summary.increases[0].amount, 0.001)
+    }
+
+    @Test
+    fun `records out of order`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 90.0, sampledAt = now),
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(90.0, summary.latestBalance!!, 0.001)
+        assertEquals(10.0, summary.totalConsumed, 0.001)
+    }
+
+    @Test
+    fun `records with same timestamp`() {
+        val now = System.currentTimeMillis()
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now),
+            createRecord(remainingBalance = 90.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertEquals(0, summary.validIntervalCount)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `different meterKeys should not mix`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(meterKey = "HEFEI:1:101", remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(meterKey = "HEFEI:1:102", remainingBalance = 50.0, sampledAt = now)
+        )
+        ElectricUsageCalculator.calculate(records)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `different meterKeys should not mix in recent 7 days`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(meterKey = "HEFEI:1:101", remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(meterKey = "HEFEI:1:102", remainingBalance = 50.0, sampledAt = now)
+        )
+        ElectricUsageCalculator.calculateRecent7DaysConsumption(records, now)
+    }
+
+    @Test
+    fun `average daily consumption calculation`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 2 * dayMs),
+            createRecord(remainingBalance = 80.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 70.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(30.0, summary.totalConsumed, 0.001)
+        assertEquals(15.0, summary.averageDailyConsumption!!, 0.001)
+    }
+
+    @Test
+    fun `estimated remaining days with positive balance`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertNotNull(summary.estimatedRemainingDays)
+        assertEquals(9.0, summary.estimatedRemainingDays!!, 0.1)
+    }
+
+    @Test
+    fun `estimated remaining days null when no consumption`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 100.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertNull(summary.estimatedRemainingDays)
+    }
+
+    @Test
+    fun `estimated remaining days null when balance is negative`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 10.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = -5.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertNull(summary.estimatedRemainingDays)
+    }
+
+    @Test
+    fun `estimated remaining days null when balance is zero`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 10.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 0.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertNull(summary.estimatedRemainingDays)
+    }
+
+    @Test
+    fun `recent 7 days consumption`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 10 * dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now - 5 * dayMs),
+            createRecord(remainingBalance = 80.0, sampledAt = now)
+        )
+        val recent7 = ElectricUsageCalculator.calculateRecent7DaysConsumption(records, now)
+        assertTrue(recent7 > 0)
+        assertTrue(recent7 <= 20.0)
+    }
+
+    @Test
+    fun `recent 7 days consumption with no recent data`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 30 * dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now - 20 * dayMs)
+        )
+        val recent7 = ElectricUsageCalculator.calculateRecent7DaysConsumption(records, now)
+        assertEquals(0.0, recent7, 0.001)
+    }
+
+    @Test
+    fun `float epsilon threshold`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 99.998, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(0, summary.validIntervalCount)
+    }
+
+    @Test
+    fun `very short time interval`() {
+        val now = System.currentTimeMillis()
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 1000),
+            createRecord(remainingBalance = 90.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(1, summary.validIntervalCount)
+        assertTrue(summary.averageDailyConsumption!! > 0)
+    }
+
+    @Test
+    fun `daily consumption keeps short interval as daily total`() {
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = timeAt(day = 25, hour = 10)),
+            createRecord(remainingBalance = 99.0, sampledAt = timeAt(day = 25, hour = 10, minute = 30))
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(1, summary.dailyConsumptions.size)
+        assertEquals(1.0, summary.dailyConsumptions.first().consumed, 0.001)
+    }
+
+    @Test
+    fun `daily consumption distributes cross-day interval by duration`() {
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = timeAt(day = 25, hour = 12)),
+            createRecord(remainingBalance = 88.0, sampledAt = timeAt(day = 26, hour = 12))
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(2, summary.dailyConsumptions.size)
+        assertEquals(6.0, summary.dailyConsumptions[0].consumed, 0.001)
+        assertEquals(6.0, summary.dailyConsumptions[1].consumed, 0.001)
+    }
+
+    @Test
+    fun `long time no change`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 100.0, sampledAt = now - 365 * dayMs),
+            createRecord(remainingBalance = 100.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(0.0, summary.totalConsumed, 0.001)
+        assertNull(summary.averageDailyConsumption)
+    }
+
+    @Test
+    fun `same meterKey normal statistics`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(meterKey = "HEFEI:1:101", remainingBalance = 100.0, sampledAt = now - 2 * dayMs),
+            createRecord(meterKey = "HEFEI:1:101", remainingBalance = 80.0, sampledAt = now - dayMs),
+            createRecord(meterKey = "HEFEI:1:101", remainingBalance = 60.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(40.0, summary.totalConsumed, 0.001)
+        assertEquals(2, summary.validIntervalCount)
+    }
+
+    @Test
+    fun `recharge interval does not produce negative consumption`() {
+        val now = System.currentTimeMillis()
+        val dayMs = 24 * 60 * 60 * 1000L
+        val records = listOf(
+            createRecord(remainingBalance = 10.0, sampledAt = now - 2 * dayMs),
+            createRecord(remainingBalance = 100.0, sampledAt = now - dayMs),
+            createRecord(remainingBalance = 90.0, sampledAt = now)
+        )
+        val summary = ElectricUsageCalculator.calculate(records)
+        assertEquals(10.0, summary.totalConsumed, 0.001)
+        assertEquals(1, summary.validIntervalCount)
+        assertEquals(1, summary.increases.size)
+        assertEquals(90.0, summary.increases[0].amount, 0.001)
+    }
+}


### PR DESCRIPTION
#86 
改的有点多，辛苦慢慢看了

## 改动说明

本 PR 为宿舍电费查询新增本地历史记录与消费趋势功能，主要包括：

* 使用 Room 保存电费余额快照，数据库版本由 5 升级至 6；
* 按校区、寝室和电表标识隔离历史数据，避免不同寝室记录混用；
* 展示余额趋势、每日估算消费、近 7 天消费、日均消费和预计剩余天数；
* 增加余额记录分页查看与清除当前电表历史功能；
* 进入电费页面后自动查询，消费趋势默认折叠；
* 首页自动查询成功后同步记录余额，不额外增加轮询请求；
* 独立处理每次电费请求，并增加请求取消和序号校验，避免快速切换寝室时旧响应覆盖新结果；
* 将宣城寝室配置迁移至 DataStore，并兼容回填旧版 SharedPrefs 配置；
* 完善网络超时、响应解析、数据库操作和协程取消等异常处理。

## 关于改动范围

历史统计需要跨 App 重启保存，因此新增了 Room 表和数据库迁移；同时，为保证历史记录与具体寝室、电表准确对应，需要调整原有共享响应式的电费查询链路。

相关改动均限制在宿舍电费功能及其直接依赖范围内，未新增第三方依赖，也未删除原有 `getFee()` 或影响其他慧新查询功能。

## 说明

每日消费等数据根据相邻两次查询之间的余额变化估算，不代表学校提供的逐日精确用电明细。所有历史数据仅保存在本机，不会上传服务器。

在合肥tab查询电费的功能好像之前的就用不了？暂未测试合肥Tab是否可用
